### PR TITLE
Update Node version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
+  - "6"
+  - "8"
+  - "10"
+
 after_script:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   "bugs": {
     "url": "https://github.com/cli-table/cli-table3/issues"
   },
-  "homepage": "https://github.com/cli-table/cli-table3"
+  "homepage": "https://github.com/cli-table/cli-table3",
+  "engines": {
+    "node": ">=6"
+  }
 }


### PR DESCRIPTION
This PR updates the Node versions that we test against on CI and officially declares the supported versions in the `package.json` file. Supported after this PR are Node 6, 8 and 10, which are the currently officially supported Node versions.

Since we previously tested against Node 0.10 and 0.11 this should be considered a breaking change, and the next release should bump the minor version since we're still pre-1.0.