### PR TITLE
Use ES6 class syntax and `let/const`

### DIFF
--- a/examples/basic-usage-examples.js
+++ b/examples/basic-usage-examples.js
@@ -1,23 +1,23 @@
-var Table = require('../src/table');
-var colors = require('colors/safe');
+const Table = require('../src/table');
+const colors = require('colors/safe');
 
 module.exports = function(runTest) {
   function it(name, fn) {
-    var result = fn();
+    let result = fn();
     runTest(name, result[0], result[1], result[2]);
   }
 
   it('Basic Usage', function() {
     function makeTable() {
       // By default, headers will be red, and borders will be grey
-      var table = new Table({ head: ['a', 'b'] });
+      let table = new Table({ head: ['a', 'b'] });
 
       table.push(['c', 'd']);
 
       return table;
     }
 
-    var expected = [
+    let expected = [
       colors.gray('┌───') + colors.gray('┬───┐'),
       colors.gray('│') + colors.red(' a ') + colors.gray('│') + colors.red(' b ') + colors.gray('│'),
       colors.gray('├───') + colors.gray('┼───┤'),
@@ -33,7 +33,7 @@ module.exports = function(runTest) {
       // For most of these examples, and most of the unit tests we disable colors.
       // It makes unit tests easier to write/understand, and allows these pages to
       // display the examples as text instead of screen shots.
-      var table = new Table({
+      let table = new Table({
         head: ['Rel', 'Change', 'By', 'When'],
         style: {
           head: [], //disable colors in header cells
@@ -50,7 +50,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌──────┬─────────────────────┬─────────────────────────┬─────────────────┐',
       '│ Rel  │ Change              │ By                      │ When            │',
       '├──────┼─────────────────────┼─────────────────────────┼─────────────────┤',
@@ -65,7 +65,7 @@ module.exports = function(runTest) {
 
   it('Create vertical tables by adding objects a that specify key-value pairs', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] },
       });
 
@@ -74,7 +74,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌────┬──────────────────────┐',
       '│v0.1│Testing something cool│',
       '├────┼──────────────────────┤',
@@ -87,7 +87,7 @@ module.exports = function(runTest) {
 
   it('Cross tables are similar to vertical tables, but include an empty string for the first header', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         head: ['', 'Header 1', 'Header 2'],
         style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] },
       }); // clear styles to prevent color output
@@ -100,7 +100,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌────────┬────────┬──────────────────────┐',
       '│        │Header 1│Header 2              │',
       '├────────┼────────┼──────────────────────┤',
@@ -115,7 +115,7 @@ module.exports = function(runTest) {
 
   it('Stylize the table with custom border characters', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         chars: {
           top: '═',
           'top-mid': '╤',
@@ -141,7 +141,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '╔══════╤═════╤══════╗',
       '║ foo  │ bar │ baz  ║',
       '╟──────┼─────┼──────╢',
@@ -154,14 +154,14 @@ module.exports = function(runTest) {
 
   it('Use ansi colors (i.e. colors.js) to style text within the cells at will, even across multiple lines', function() {
     function makeTable() {
-      var table = new Table({ style: { border: [], header: [] } });
+      let table = new Table({ style: { border: [], header: [] } });
 
       table.push([colors.red('Hello\nhow\nare\nyou?'), colors.blue('I\nam\nfine\nthanks!')]);
 
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────┬─────────┐',
       '│ ' + colors.red('Hello') + ' │ ' + colors.blue('I') + '       │',
       '│ ' + colors.red('how') + '   │ ' + colors.blue('am') + '      │',
@@ -175,7 +175,7 @@ module.exports = function(runTest) {
 
   it('Set `wordWrap` to true to make lines of text wrap instead of being truncated', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         style: { border: [], header: [] },
         colWidths: [7, 9],
         wordWrap: true,
@@ -186,7 +186,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────┬─────────┐',
       '│ Hello │ I am    │',
       '│ how   │ fine    │',
@@ -202,7 +202,7 @@ module.exports = function(runTest) {
 /* Expectation - ready to be copy/pasted and filled in. DO NOT DELETE THIS
 
 
- var expected = [
+ let expected = [
    '┌──┬───┬──┬──┐'
  , '│  │   │  │  │'
  , '├──┼───┼──┼──┤'

--- a/examples/col-and-row-span-examples.js
+++ b/examples/col-and-row-span-examples.js
@@ -1,22 +1,22 @@
-var Table = require('../src/table');
-var colors = require('colors/safe');
+const Table = require('../src/table');
+const colors = require('colors/safe');
 
 module.exports = function(runTest) {
   function it(name, fn) {
-    var result = fn();
+    let result = fn();
     runTest(name, result[0], result[1], result[2]);
   }
 
   it('use colSpan to span columns - (colSpan above normal cell)', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push([{ colSpan: 2, content: 'greetings' }], [{ colSpan: 2, content: 'greetings' }], ['hello', 'howdy']);
 
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────────────┐',
       '│ greetings     │',
       '├───────────────┤',
@@ -31,14 +31,14 @@ module.exports = function(runTest) {
 
   it('use colSpan to span columns - (colSpan below normal cell)', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push(['hello', 'howdy'], [{ colSpan: 2, content: 'greetings' }], [{ colSpan: 2, content: 'greetings' }]);
 
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────┬───────┐',
       '│ hello │ howdy │',
       '├───────┴───────┤',
@@ -53,7 +53,7 @@ module.exports = function(runTest) {
 
   it('use rowSpan to span rows - (rowSpan on the left side)', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push(
         [{ rowSpan: 2, content: 'greetings' }, { rowSpan: 2, content: 'greetings', vAlign: 'center' }, 'hello'],
@@ -63,7 +63,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────────┬───────────┬───────┐',
       '│ greetings │           │ hello │',
       '│           │ greetings ├───────┤',
@@ -76,7 +76,7 @@ module.exports = function(runTest) {
 
   it('use rowSpan to span rows - (rowSpan on the right side)', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push(
         ['hello', { rowSpan: 2, content: 'greetings' }, { rowSpan: 2, content: 'greetings', vAlign: 'bottom' }],
@@ -86,7 +86,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────┬───────────┬───────────┐',
       '│ hello │ greetings │           │',
       '├───────┤           │           │',
@@ -99,7 +99,7 @@ module.exports = function(runTest) {
 
   it('mix rowSpan and colSpan together for complex table layouts', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push(
         [{ content: 'hello', colSpan: 2 }, { rowSpan: 2, colSpan: 2, content: 'sup' }, { rowSpan: 3, content: 'hi' }],
@@ -110,7 +110,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────┬─────┬────┐',
       '│ hello │ sup │ hi │',
       '├───────┤     │    │',
@@ -125,7 +125,7 @@ module.exports = function(runTest) {
 
   it('multi-line content will flow across rows in rowSpan cells', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push(
         ['hello', { rowSpan: 2, content: 'greetings\nfriends' }, { rowSpan: 2, content: 'greetings\nfriends' }],
@@ -135,7 +135,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────┬───────────┬───────────┐',
       '│ hello │ greetings │ greetings │',
       '├───────┤ friends   │ friends   │',
@@ -148,7 +148,7 @@ module.exports = function(runTest) {
 
   it('multi-line content will flow across rows in rowSpan cells - (complex layout)', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push(
         [
@@ -163,7 +163,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───────┬─────┬────┐',
       '│ hello │ sup │ hi │',
       '├───────┤ man │ yo │',
@@ -178,28 +178,28 @@ module.exports = function(runTest) {
 
   it('rowSpan cells can have a staggered layout', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push([{ content: 'a', rowSpan: 2 }, 'b'], [{ content: 'c', rowSpan: 2 }], ['d']);
 
       return table;
     }
 
-    var expected = ['┌───┬───┐', '│ a │ b │', '│   ├───┤', '│   │ c │', '├───┤   │', '│ d │   │', '└───┴───┘'];
+    let expected = ['┌───┬───┐', '│ a │ b │', '│   ├───┤', '│   │ c │', '├───┤   │', '│ d │   │', '└───┴───┘'];
 
     return [makeTable, expected];
   });
 
   it('the layout manager automatically create empty cells to fill in the table', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       //notice we only create 3 cells here, but the table ends up having 6.
       table.push([{ content: 'a', rowSpan: 3, colSpan: 2 }, 'b'], [], [{ content: 'c', rowSpan: 2, colSpan: 2 }], []);
       return table;
     }
 
-    var expected = [
+    let expected = [
       '┌───┬───┬──┐',
       '│ a │ b │  │', // top-right and bottom-left cells are automatically created to fill the empty space
       '│   ├───┤  │',
@@ -216,7 +216,7 @@ module.exports = function(runTest) {
 
   it('use table `rowHeights` option to fix row height. The truncation symbol will be shown on the last line.', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         rowHeights: [2],
         style: { head: [], border: [] },
       });
@@ -226,28 +226,28 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = ['┌───────┐', '│ hello │', '│ hi…   │', '└───────┘'];
+    let expected = ['┌───────┐', '│ hello │', '│ hi…   │', '└───────┘'];
 
     return [makeTable, expected];
   });
 
   it('if `colWidths` is not specified, the layout manager will automatically widen rows to fit the content', function() {
     function makeTable() {
-      var table = new Table({ style: { head: [], border: [] } });
+      let table = new Table({ style: { head: [], border: [] } });
 
       table.push([{ colSpan: 2, content: 'hello there' }], ['hi', 'hi']);
 
       return table;
     }
 
-    var expected = ['┌─────────────┐', '│ hello there │', '├──────┬──────┤', '│ hi   │ hi   │', '└──────┴──────┘'];
+    let expected = ['┌─────────────┐', '│ hello there │', '├──────┬──────┤', '│ hi   │ hi   │', '└──────┴──────┘'];
 
     return [makeTable, expected];
   });
 
   it('you can specify a column width for only the first row, other rows will be automatically widened to fit content', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         colWidths: [4],
         style: { head: [], border: [] },
       });
@@ -257,14 +257,14 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = ['┌─────────────┐', '│ hello there │', '├────┬────────┤', '│ hi │   hi   │', '└────┴────────┘'];
+    let expected = ['┌─────────────┐', '│ hello there │', '├────┬────────┤', '│ hi │   hi   │', '└────┴────────┘'];
 
     return [makeTable, expected];
   });
 
   it('a column with a null column width will be automatically widened to fit content', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         colWidths: [null, 4],
         style: { head: [], border: [] },
       });
@@ -274,14 +274,14 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = ['┌─────────────┐', '│ hello there │', '├────────┬────┤', '│     hi │ hi │', '└────────┴────┘'];
+    let expected = ['┌─────────────┐', '│ hello there │', '├────────┬────┤', '│     hi │ hi │', '└────────┴────┘'];
 
     return [makeTable, expected];
   });
 
   it('feel free to use colors in your content strings, column widths will be calculated correctly', function() {
     function makeTable() {
-      var table = new Table({
+      let table = new Table({
         colWidths: [5],
         style: { head: [], border: [] },
       });
@@ -291,7 +291,7 @@ module.exports = function(runTest) {
       return table;
     }
 
-    var expected = ['┌─────┐', '│ ' + colors.red('he') + '… │', '└─────┘'];
+    let expected = ['┌─────┐', '│ ' + colors.red('he') + '… │', '└─────┘'];
 
     return [makeTable, expected, 'truncation-with-colors'];
   });
@@ -299,7 +299,7 @@ module.exports = function(runTest) {
 
 /*
 
- var expected = [
+ let expected = [
    '┌──┬───┬──┬──┐'
  , '│  │   │  │  │'
  , '├──┼───┼──┼──┤'

--- a/lib/print-example.js
+++ b/lib/print-example.js
@@ -1,9 +1,9 @@
 /* eslint-env jest */
 /* eslint-disable no-console */
 
-var colors = require('colors/safe');
-var fs = require('fs');
-var git = require('git-rev');
+const colors = require('colors/safe');
+const fs = require('fs');
+const git = require('git-rev');
 
 function logExample(fn) {
   runPrintingExample(
@@ -20,7 +20,7 @@ function logExample(fn) {
 
 function mdExample(fn, file, cb) {
   git.long(function(commitHash) {
-    var buffer = [];
+    let buffer = [];
 
     runPrintingExample(
       fn,
@@ -98,7 +98,7 @@ function runPrintingExample(fn, logName, logTable, logCode, logSeparator, logScr
    * @param screenshot - If present, there is an image containing a screenshot of the output
    */
   function printExample(name, makeTable, expected, screenshot) {
-    var code = makeTable
+    let code = makeTable
       .toString()
       .split('\n')
       .slice(1, -2)

--- a/src/cell.js
+++ b/src/cell.js
@@ -1,5 +1,5 @@
-var kindOf = require('kind-of');
-var utils = require('./utils');
+const kindOf = require('kind-of');
+const utils = require('./utils');
 
 class Cell {
   /**
@@ -27,7 +27,7 @@ class Cell {
     }
     options = options || {};
     this.options = options;
-    var content = options.content;
+    let content = options.content;
     if (['boolean', 'number', 'string'].indexOf(kindOf(content)) !== -1) {
       this.content = String(content);
     } else if (!content) {
@@ -42,27 +42,27 @@ class Cell {
   mergeTableOptions(tableOptions, cells) {
     this.cells = cells;
 
-    var optionsChars = this.options.chars || {};
-    var tableChars = tableOptions.chars;
-    var chars = (this.chars = {});
+    let optionsChars = this.options.chars || {};
+    let tableChars = tableOptions.chars;
+    let chars = (this.chars = {});
     CHAR_NAMES.forEach(function(name) {
       setOption(optionsChars, tableChars, name, chars);
     });
 
     this.truncate = this.options.truncate || tableOptions.truncate;
 
-    var style = (this.options.style = this.options.style || {});
-    var tableStyle = tableOptions.style;
+    let style = (this.options.style = this.options.style || {});
+    let tableStyle = tableOptions.style;
     setOption(style, tableStyle, 'padding-left', this);
     setOption(style, tableStyle, 'padding-right', this);
     this.head = style.head || tableStyle.head;
     this.border = style.border || tableStyle.border;
 
-    var fixedWidth = tableOptions.colWidths[this.x];
+    let fixedWidth = tableOptions.colWidths[this.x];
     if (tableOptions.wordWrap && fixedWidth) {
       fixedWidth -= this.paddingLeft + this.paddingRight;
       if (this.colSpan) {
-        var i = 1;
+        let i = 1;
         while (i < this.colSpan) {
           fixedWidth += tableOptions.colWidths[this.x + i];
           i++;
@@ -87,8 +87,8 @@ class Cell {
    *
    */
   init(tableOptions) {
-    var x = this.x;
-    var y = this.y;
+    let x = this.x;
+    let y = this.y;
     this.widths = tableOptions.colWidths.slice(x, x + this.colSpan);
     this.heights = tableOptions.rowHeights.slice(y, y + this.rowSpan);
     this.width = this.widths.reduce(sumPlusOne, -1);
@@ -111,8 +111,8 @@ class Cell {
   draw(lineNum, spanningCell) {
     if (lineNum == 'top') return this.drawTop(this.drawRight);
     if (lineNum == 'bottom') return this.drawBottom(this.drawRight);
-    var padLen = Math.max(this.height - this.lines.length, 0);
-    var padTop;
+    let padLen = Math.max(this.height - this.lines.length, 0);
+    let padTop;
     switch (this.vAlign) {
       case 'center':
         padTop = Math.ceil(padLen / 2);
@@ -126,7 +126,7 @@ class Cell {
     if (lineNum < padTop || lineNum >= padTop + this.lines.length) {
       return this.drawEmpty(this.drawRight, spanningCell);
     }
-    var forceTruncation = this.lines.length > this.height && lineNum + 1 >= this.height;
+    let forceTruncation = this.lines.length > this.height && lineNum + 1 >= this.height;
     return this.drawLine(lineNum - padTop, this.drawRight, forceTruncation, spanningCell);
   }
 
@@ -136,7 +136,7 @@ class Cell {
    * @returns {String}
    */
   drawTop(drawRight) {
-    var content = [];
+    let content = [];
     if (this.cells) {
       //TODO: cells should always exist - some tests don't fill it in though
       this.widths.forEach(function(width, index) {
@@ -154,8 +154,8 @@ class Cell {
   }
 
   _topLeftChar(offset) {
-    var x = this.x + offset;
-    var leftChar;
+    let x = this.x + offset;
+    let leftChar;
     if (this.y == 0) {
       leftChar = x == 0 ? 'topLeft' : offset == 0 ? 'topMid' : 'top';
     } else {
@@ -165,12 +165,12 @@ class Cell {
         leftChar = offset == 0 ? 'midMid' : 'bottomMid';
         if (this.cells) {
           //TODO: cells should always exist - some tests don't fill it in though
-          var spanAbove = this.cells[this.y - 1][x] instanceof Cell.ColSpanCell;
+          let spanAbove = this.cells[this.y - 1][x] instanceof Cell.ColSpanCell;
           if (spanAbove) {
             leftChar = offset == 0 ? 'topMid' : 'mid';
           }
           if (offset == 0) {
-            var i = 1;
+            let i = 1;
             while (this.cells[this.y][x - i] instanceof Cell.ColSpanCell) {
               i++;
             }
@@ -187,8 +187,8 @@ class Cell {
   wrapWithStyleColors(styleProperty, content) {
     if (this[styleProperty] && this[styleProperty].length) {
       try {
-        var colors = require('colors/safe');
-        for (var i = this[styleProperty].length - 1; i >= 0; i--) {
+        let colors = require('colors/safe');
+        for (let i = this[styleProperty].length - 1; i >= 0; i--) {
           colors = colors[this[styleProperty][i]];
         }
         return colors(content);
@@ -212,9 +212,9 @@ class Cell {
    * @returns {String}
    */
   drawLine(lineNum, drawRight, forceTruncationSymbol, spanningCell) {
-    var left = this.chars[this.x == 0 ? 'left' : 'middle'];
+    let left = this.chars[this.x == 0 ? 'left' : 'middle'];
     if (this.x && spanningCell && this.cells) {
-      var cellLeft = this.cells[this.y + spanningCell][this.x - 1];
+      let cellLeft = this.cells[this.y + spanningCell][this.x - 1];
       while (cellLeft instanceof ColSpanCell) {
         cellLeft = this.cells[cellLeft.y][cellLeft.x - 1];
       }
@@ -222,13 +222,13 @@ class Cell {
         left = this.chars['rightMid'];
       }
     }
-    var leftPadding = utils.repeat(' ', this.paddingLeft);
-    var right = drawRight ? this.chars['right'] : '';
-    var rightPadding = utils.repeat(' ', this.paddingRight);
-    var line = this.lines[lineNum];
-    var len = this.width - (this.paddingLeft + this.paddingRight);
+    let leftPadding = utils.repeat(' ', this.paddingLeft);
+    let right = drawRight ? this.chars['right'] : '';
+    let rightPadding = utils.repeat(' ', this.paddingRight);
+    let line = this.lines[lineNum];
+    let len = this.width - (this.paddingLeft + this.paddingRight);
     if (forceTruncationSymbol) line += this.truncate || '…';
-    var content = utils.truncate(line, len, this.truncate);
+    let content = utils.truncate(line, len, this.truncate);
     content = utils.pad(content, len, ' ', this.hAlign);
     content = leftPadding + content + rightPadding;
     return this.stylizeLine(left, content, right);
@@ -249,9 +249,9 @@ class Cell {
    * @returns {String}
    */
   drawBottom(drawRight) {
-    var left = this.chars[this.x == 0 ? 'bottomLeft' : 'bottomMid'];
-    var content = utils.repeat(this.chars.bottom, this.width);
-    var right = drawRight ? this.chars['bottomRight'] : '';
+    let left = this.chars[this.x == 0 ? 'bottomLeft' : 'bottomMid'];
+    let content = utils.repeat(this.chars.bottom, this.width);
+    let right = drawRight ? this.chars['bottomRight'] : '';
     return this.wrapWithStyleColors('border', left + content + right);
   }
 
@@ -262,9 +262,9 @@ class Cell {
    * @returns {String}
    */
   drawEmpty(drawRight, spanningCell) {
-    var left = this.chars[this.x == 0 ? 'left' : 'middle'];
+    let left = this.chars[this.x == 0 ? 'left' : 'middle'];
     if (this.x && spanningCell && this.cells) {
-      var cellLeft = this.cells[this.y + spanningCell][this.x - 1];
+      let cellLeft = this.cells[this.y + spanningCell][this.x - 1];
       while (cellLeft instanceof ColSpanCell) {
         cellLeft = this.cells[cellLeft.y][cellLeft.x - 1];
       }
@@ -272,8 +272,8 @@ class Cell {
         left = this.chars['rightMid'];
       }
     }
-    var right = drawRight ? this.chars['right'] : '';
-    var content = utils.repeat(' ', this.width);
+    let right = drawRight ? this.chars['right'] : '';
+    let content = utils.repeat(' ', this.width);
     return this.stylizeLine(left, content, right);
   }
 }
@@ -307,8 +307,8 @@ class RowSpanCell {
   }
 
   init(tableOptions) {
-    var y = this.y;
-    var originalY = this.originalCell.y;
+    let y = this.y;
+    let originalY = this.originalCell.y;
     this.cellOffset = y - originalY;
     this.offset = findDimension(tableOptions.rowHeights, originalY, this.cellOffset);
   }
@@ -328,7 +328,7 @@ class RowSpanCell {
 
 // HELPER FUNCTIONS
 function setOption(objA, objB, nameB, targetObj) {
-  var nameA = nameB.split('-');
+  let nameA = nameB.split('-');
   if (nameA.length > 1) {
     nameA[1] = nameA[1].charAt(0).toUpperCase() + nameA[1].substr(1);
     nameA = nameA.join('');
@@ -339,8 +339,8 @@ function setOption(objA, objB, nameB, targetObj) {
 }
 
 function findDimension(dimensionTable, startingIndex, span) {
-  var ret = dimensionTable[startingIndex];
-  for (var i = 1; i < span; i++) {
+  let ret = dimensionTable[startingIndex];
+  for (let i = 1; i < span; i++) {
     ret += 1 + dimensionTable[startingIndex + i];
   }
   return ret;
@@ -350,7 +350,7 @@ function sumPlusOne(a, b) {
   return a + b + 1;
 }
 
-var CHAR_NAMES = [
+let CHAR_NAMES = [
   'top',
   'top-mid',
   'top-left',

--- a/src/cell.js
+++ b/src/cell.js
@@ -277,18 +277,22 @@ Cell.prototype.drawEmpty = function(drawRight, spanningCell) {
   return this.stylizeLine(left, content, right);
 };
 
-/**
- * A Cell that doesn't do anything. It just draws empty lines.
- * Used as a placeholder in column spanning.
- * @constructor
- */
-function ColSpanCell() {}
+class ColSpanCell {
+  /**
+   * A Cell that doesn't do anything. It just draws empty lines.
+   * Used as a placeholder in column spanning.
+   * @constructor
+   */
+  constructor() {}
 
-ColSpanCell.prototype.draw = function() {
-  return '';
-};
+  draw() {
+    return '';
+  }
 
-ColSpanCell.prototype.init = function(/* tableOptions */) {};
+  init() {}
+
+  mergeTableOptions() {}
+}
 
 class RowSpanCell {
   /**
@@ -320,8 +324,6 @@ class RowSpanCell {
 
   mergeTableOptions() {}
 }
-
-ColSpanCell.prototype.mergeTableOptions = function() {};
 
 // HELPER FUNCTIONS
 function setOption(objA, objB, nameB, targetObj) {

--- a/src/cell.js
+++ b/src/cell.js
@@ -290,34 +290,38 @@ ColSpanCell.prototype.draw = function() {
 
 ColSpanCell.prototype.init = function(/* tableOptions */) {};
 
-/**
- * A placeholder Cell for a Cell that spans multiple rows.
- * It delegates rendering to the original cell, but adds the appropriate offset.
- * @param originalCell
- * @constructor
- */
-function RowSpanCell(originalCell) {
-  this.originalCell = originalCell;
+class RowSpanCell {
+  /**
+   * A placeholder Cell for a Cell that spans multiple rows.
+   * It delegates rendering to the original cell, but adds the appropriate offset.
+   * @param originalCell
+   * @constructor
+   */
+  constructor(originalCell) {
+    this.originalCell = originalCell;
+  }
+
+  init(tableOptions) {
+    var y = this.y;
+    var originalY = this.originalCell.y;
+    this.cellOffset = y - originalY;
+    this.offset = findDimension(tableOptions.rowHeights, originalY, this.cellOffset);
+  }
+
+  draw(lineNum) {
+    if (lineNum == 'top') {
+      return this.originalCell.draw(this.offset, this.cellOffset);
+    }
+    if (lineNum == 'bottom') {
+      return this.originalCell.draw('bottom');
+    }
+    return this.originalCell.draw(this.offset + 1 + lineNum);
+  }
+
+  mergeTableOptions() {}
 }
 
-RowSpanCell.prototype.init = function(tableOptions) {
-  var y = this.y;
-  var originalY = this.originalCell.y;
-  this.cellOffset = y - originalY;
-  this.offset = findDimension(tableOptions.rowHeights, originalY, this.cellOffset);
-};
-
-RowSpanCell.prototype.draw = function(lineNum) {
-  if (lineNum == 'top') {
-    return this.originalCell.draw(this.offset, this.cellOffset);
-  }
-  if (lineNum == 'bottom') {
-    return this.originalCell.draw('bottom');
-  }
-  return this.originalCell.draw(this.offset + 1 + lineNum);
-};
-
-ColSpanCell.prototype.mergeTableOptions = RowSpanCell.prototype.mergeTableOptions = function() {};
+ColSpanCell.prototype.mergeTableOptions = function() {};
 
 // HELPER FUNCTIONS
 function setOption(objA, objB, nameB, targetObj) {

--- a/src/cell.js
+++ b/src/cell.js
@@ -1,281 +1,282 @@
 var kindOf = require('kind-of');
 var utils = require('./utils');
 
-/**
- * A representation of a cell within the table.
- * Implementations must have `init` and `draw` methods,
- * as well as `colSpan`, `rowSpan`, `desiredHeight` and `desiredWidth` properties.
- * @param options
- * @constructor
- */
-function Cell(options) {
-  this.setOptions(options);
-}
+class Cell {
+  /**
+   * A representation of a cell within the table.
+   * Implementations must have `init` and `draw` methods,
+   * as well as `colSpan`, `rowSpan`, `desiredHeight` and `desiredWidth` properties.
+   * @param options
+   * @constructor
+   */
+  constructor(options) {
+    this.setOptions(options);
 
-Cell.prototype.setOptions = function(options) {
-  if (['boolean', 'number', 'string'].indexOf(kindOf(options)) !== -1) {
-    options = { content: '' + options };
+    /**
+     * Each cell will have it's `x` and `y` values set by the `layout-manager` prior to
+     * `init` being called;
+     * @type {Number}
+     */
+    this.x = null;
+    this.y = null;
   }
-  options = options || {};
-  this.options = options;
-  var content = options.content;
-  if (['boolean', 'number', 'string'].indexOf(kindOf(content)) !== -1) {
-    this.content = String(content);
-  } else if (!content) {
-    this.content = '';
-  } else {
-    throw new Error('Content needs to be a primitive, got: ' + typeof content);
-  }
-  this.colSpan = options.colSpan || 1;
-  this.rowSpan = options.rowSpan || 1;
-};
 
-Cell.prototype.mergeTableOptions = function(tableOptions, cells) {
-  this.cells = cells;
-
-  var optionsChars = this.options.chars || {};
-  var tableChars = tableOptions.chars;
-  var chars = (this.chars = {});
-  CHAR_NAMES.forEach(function(name) {
-    setOption(optionsChars, tableChars, name, chars);
-  });
-
-  this.truncate = this.options.truncate || tableOptions.truncate;
-
-  var style = (this.options.style = this.options.style || {});
-  var tableStyle = tableOptions.style;
-  setOption(style, tableStyle, 'padding-left', this);
-  setOption(style, tableStyle, 'padding-right', this);
-  this.head = style.head || tableStyle.head;
-  this.border = style.border || tableStyle.border;
-
-  var fixedWidth = tableOptions.colWidths[this.x];
-  if (tableOptions.wordWrap && fixedWidth) {
-    fixedWidth -= this.paddingLeft + this.paddingRight;
-    if (this.colSpan) {
-      var i = 1;
-      while (i < this.colSpan) {
-        fixedWidth += tableOptions.colWidths[this.x + i];
-        i++;
-      }
+  setOptions(options) {
+    if (['boolean', 'number', 'string'].indexOf(kindOf(options)) !== -1) {
+      options = { content: '' + options };
     }
-    this.lines = utils.colorizeLines(utils.wordWrap(fixedWidth, this.content));
-  } else {
-    this.lines = utils.colorizeLines(this.content.split('\n'));
-  }
-
-  this.desiredWidth = utils.strlen(this.content) + this.paddingLeft + this.paddingRight;
-  this.desiredHeight = this.lines.length;
-};
-
-/**
- * Each cell will have it's `x` and `y` values set by the `layout-manager` prior to
- * `init` being called;
- * @type {Number}
- */
-
-Cell.prototype.x = null;
-Cell.prototype.y = null;
-
-/**
- * Initializes the Cells data structure.
- *
- * @param tableOptions - A fully populated set of tableOptions.
- * In addition to the standard default values, tableOptions must have fully populated the
- * `colWidths` and `rowWidths` arrays. Those arrays must have lengths equal to the number
- * of columns or rows (respectively) in this table, and each array item must be a Number.
- *
- */
-Cell.prototype.init = function(tableOptions) {
-  var x = this.x;
-  var y = this.y;
-  this.widths = tableOptions.colWidths.slice(x, x + this.colSpan);
-  this.heights = tableOptions.rowHeights.slice(y, y + this.rowSpan);
-  this.width = this.widths.reduce(sumPlusOne, -1);
-  this.height = this.heights.reduce(sumPlusOne, -1);
-
-  this.hAlign = this.options.hAlign || tableOptions.colAligns[x];
-  this.vAlign = this.options.vAlign || tableOptions.rowAligns[y];
-
-  this.drawRight = x + this.colSpan == tableOptions.colWidths.length;
-};
-
-/**
- * Draws the given line of the cell.
- * This default implementation defers to methods `drawTop`, `drawBottom`, `drawLine` and `drawEmpty`.
- * @param lineNum - can be `top`, `bottom` or a numerical line number.
- * @param spanningCell - will be a number if being called from a RowSpanCell, and will represent how
- * many rows below it's being called from. Otherwise it's undefined.
- * @returns {String} The representation of this line.
- */
-Cell.prototype.draw = function(lineNum, spanningCell) {
-  if (lineNum == 'top') return this.drawTop(this.drawRight);
-  if (lineNum == 'bottom') return this.drawBottom(this.drawRight);
-  var padLen = Math.max(this.height - this.lines.length, 0);
-  var padTop;
-  switch (this.vAlign) {
-    case 'center':
-      padTop = Math.ceil(padLen / 2);
-      break;
-    case 'bottom':
-      padTop = padLen;
-      break;
-    default:
-      padTop = 0;
-  }
-  if (lineNum < padTop || lineNum >= padTop + this.lines.length) {
-    return this.drawEmpty(this.drawRight, spanningCell);
-  }
-  var forceTruncation = this.lines.length > this.height && lineNum + 1 >= this.height;
-  return this.drawLine(lineNum - padTop, this.drawRight, forceTruncation, spanningCell);
-};
-
-/**
- * Renders the top line of the cell.
- * @param drawRight - true if this method should render the right edge of the cell.
- * @returns {String}
- */
-Cell.prototype.drawTop = function(drawRight) {
-  var content = [];
-  if (this.cells) {
-    //TODO: cells should always exist - some tests don't fill it in though
-    this.widths.forEach(function(width, index) {
-      content.push(this._topLeftChar(index));
-      content.push(utils.repeat(this.chars[this.y == 0 ? 'top' : 'mid'], width));
-    }, this);
-  } else {
-    content.push(this._topLeftChar(0));
-    content.push(utils.repeat(this.chars[this.y == 0 ? 'top' : 'mid'], this.width));
-  }
-  if (drawRight) {
-    content.push(this.chars[this.y == 0 ? 'topRight' : 'rightMid']);
-  }
-  return this.wrapWithStyleColors('border', content.join(''));
-};
-
-Cell.prototype._topLeftChar = function(offset) {
-  var x = this.x + offset;
-  var leftChar;
-  if (this.y == 0) {
-    leftChar = x == 0 ? 'topLeft' : offset == 0 ? 'topMid' : 'top';
-  } else {
-    if (x == 0) {
-      leftChar = 'leftMid';
+    options = options || {};
+    this.options = options;
+    var content = options.content;
+    if (['boolean', 'number', 'string'].indexOf(kindOf(content)) !== -1) {
+      this.content = String(content);
+    } else if (!content) {
+      this.content = '';
     } else {
-      leftChar = offset == 0 ? 'midMid' : 'bottomMid';
-      if (this.cells) {
-        //TODO: cells should always exist - some tests don't fill it in though
-        var spanAbove = this.cells[this.y - 1][x] instanceof Cell.ColSpanCell;
-        if (spanAbove) {
-          leftChar = offset == 0 ? 'topMid' : 'mid';
+      throw new Error('Content needs to be a primitive, got: ' + typeof content);
+    }
+    this.colSpan = options.colSpan || 1;
+    this.rowSpan = options.rowSpan || 1;
+  }
+
+  mergeTableOptions(tableOptions, cells) {
+    this.cells = cells;
+
+    var optionsChars = this.options.chars || {};
+    var tableChars = tableOptions.chars;
+    var chars = (this.chars = {});
+    CHAR_NAMES.forEach(function(name) {
+      setOption(optionsChars, tableChars, name, chars);
+    });
+
+    this.truncate = this.options.truncate || tableOptions.truncate;
+
+    var style = (this.options.style = this.options.style || {});
+    var tableStyle = tableOptions.style;
+    setOption(style, tableStyle, 'padding-left', this);
+    setOption(style, tableStyle, 'padding-right', this);
+    this.head = style.head || tableStyle.head;
+    this.border = style.border || tableStyle.border;
+
+    var fixedWidth = tableOptions.colWidths[this.x];
+    if (tableOptions.wordWrap && fixedWidth) {
+      fixedWidth -= this.paddingLeft + this.paddingRight;
+      if (this.colSpan) {
+        var i = 1;
+        while (i < this.colSpan) {
+          fixedWidth += tableOptions.colWidths[this.x + i];
+          i++;
         }
-        if (offset == 0) {
-          var i = 1;
-          while (this.cells[this.y][x - i] instanceof Cell.ColSpanCell) {
-            i++;
+      }
+      this.lines = utils.colorizeLines(utils.wordWrap(fixedWidth, this.content));
+    } else {
+      this.lines = utils.colorizeLines(this.content.split('\n'));
+    }
+
+    this.desiredWidth = utils.strlen(this.content) + this.paddingLeft + this.paddingRight;
+    this.desiredHeight = this.lines.length;
+  }
+
+  /**
+   * Initializes the Cells data structure.
+   *
+   * @param tableOptions - A fully populated set of tableOptions.
+   * In addition to the standard default values, tableOptions must have fully populated the
+   * `colWidths` and `rowWidths` arrays. Those arrays must have lengths equal to the number
+   * of columns or rows (respectively) in this table, and each array item must be a Number.
+   *
+   */
+  init(tableOptions) {
+    var x = this.x;
+    var y = this.y;
+    this.widths = tableOptions.colWidths.slice(x, x + this.colSpan);
+    this.heights = tableOptions.rowHeights.slice(y, y + this.rowSpan);
+    this.width = this.widths.reduce(sumPlusOne, -1);
+    this.height = this.heights.reduce(sumPlusOne, -1);
+
+    this.hAlign = this.options.hAlign || tableOptions.colAligns[x];
+    this.vAlign = this.options.vAlign || tableOptions.rowAligns[y];
+
+    this.drawRight = x + this.colSpan == tableOptions.colWidths.length;
+  }
+
+  /**
+   * Draws the given line of the cell.
+   * This default implementation defers to methods `drawTop`, `drawBottom`, `drawLine` and `drawEmpty`.
+   * @param lineNum - can be `top`, `bottom` or a numerical line number.
+   * @param spanningCell - will be a number if being called from a RowSpanCell, and will represent how
+   * many rows below it's being called from. Otherwise it's undefined.
+   * @returns {String} The representation of this line.
+   */
+  draw(lineNum, spanningCell) {
+    if (lineNum == 'top') return this.drawTop(this.drawRight);
+    if (lineNum == 'bottom') return this.drawBottom(this.drawRight);
+    var padLen = Math.max(this.height - this.lines.length, 0);
+    var padTop;
+    switch (this.vAlign) {
+      case 'center':
+        padTop = Math.ceil(padLen / 2);
+        break;
+      case 'bottom':
+        padTop = padLen;
+        break;
+      default:
+        padTop = 0;
+    }
+    if (lineNum < padTop || lineNum >= padTop + this.lines.length) {
+      return this.drawEmpty(this.drawRight, spanningCell);
+    }
+    var forceTruncation = this.lines.length > this.height && lineNum + 1 >= this.height;
+    return this.drawLine(lineNum - padTop, this.drawRight, forceTruncation, spanningCell);
+  }
+
+  /**
+   * Renders the top line of the cell.
+   * @param drawRight - true if this method should render the right edge of the cell.
+   * @returns {String}
+   */
+  drawTop(drawRight) {
+    var content = [];
+    if (this.cells) {
+      //TODO: cells should always exist - some tests don't fill it in though
+      this.widths.forEach(function(width, index) {
+        content.push(this._topLeftChar(index));
+        content.push(utils.repeat(this.chars[this.y == 0 ? 'top' : 'mid'], width));
+      }, this);
+    } else {
+      content.push(this._topLeftChar(0));
+      content.push(utils.repeat(this.chars[this.y == 0 ? 'top' : 'mid'], this.width));
+    }
+    if (drawRight) {
+      content.push(this.chars[this.y == 0 ? 'topRight' : 'rightMid']);
+    }
+    return this.wrapWithStyleColors('border', content.join(''));
+  }
+
+  _topLeftChar(offset) {
+    var x = this.x + offset;
+    var leftChar;
+    if (this.y == 0) {
+      leftChar = x == 0 ? 'topLeft' : offset == 0 ? 'topMid' : 'top';
+    } else {
+      if (x == 0) {
+        leftChar = 'leftMid';
+      } else {
+        leftChar = offset == 0 ? 'midMid' : 'bottomMid';
+        if (this.cells) {
+          //TODO: cells should always exist - some tests don't fill it in though
+          var spanAbove = this.cells[this.y - 1][x] instanceof Cell.ColSpanCell;
+          if (spanAbove) {
+            leftChar = offset == 0 ? 'topMid' : 'mid';
           }
-          if (this.cells[this.y][x - i] instanceof Cell.RowSpanCell) {
-            leftChar = 'leftMid';
+          if (offset == 0) {
+            var i = 1;
+            while (this.cells[this.y][x - i] instanceof Cell.ColSpanCell) {
+              i++;
+            }
+            if (this.cells[this.y][x - i] instanceof Cell.RowSpanCell) {
+              leftChar = 'leftMid';
+            }
           }
         }
       }
     }
+    return this.chars[leftChar];
   }
-  return this.chars[leftChar];
-};
 
-Cell.prototype.wrapWithStyleColors = function(styleProperty, content) {
-  if (this[styleProperty] && this[styleProperty].length) {
-    try {
-      var colors = require('colors/safe');
-      for (var i = this[styleProperty].length - 1; i >= 0; i--) {
-        colors = colors[this[styleProperty][i]];
+  wrapWithStyleColors(styleProperty, content) {
+    if (this[styleProperty] && this[styleProperty].length) {
+      try {
+        var colors = require('colors/safe');
+        for (var i = this[styleProperty].length - 1; i >= 0; i--) {
+          colors = colors[this[styleProperty][i]];
+        }
+        return colors(content);
+      } catch (e) {
+        return content;
       }
-      return colors(content);
-    } catch (e) {
+    } else {
       return content;
     }
-  } else {
-    return content;
   }
-};
 
-/**
- * Renders a line of text.
- * @param lineNum - Which line of text to render. This is not necessarily the line within the cell.
- * There may be top-padding above the first line of text.
- * @param drawRight - true if this method should render the right edge of the cell.
- * @param forceTruncationSymbol - `true` if the rendered text should end with the truncation symbol even
- * if the text fits. This is used when the cell is vertically truncated. If `false` the text should
- * only include the truncation symbol if the text will not fit horizontally within the cell width.
- * @param spanningCell - a number of if being called from a RowSpanCell. (how many rows below). otherwise undefined.
- * @returns {String}
- */
-Cell.prototype.drawLine = function(lineNum, drawRight, forceTruncationSymbol, spanningCell) {
-  var left = this.chars[this.x == 0 ? 'left' : 'middle'];
-  if (this.x && spanningCell && this.cells) {
-    var cellLeft = this.cells[this.y + spanningCell][this.x - 1];
-    while (cellLeft instanceof ColSpanCell) {
-      cellLeft = this.cells[cellLeft.y][cellLeft.x - 1];
+  /**
+   * Renders a line of text.
+   * @param lineNum - Which line of text to render. This is not necessarily the line within the cell.
+   * There may be top-padding above the first line of text.
+   * @param drawRight - true if this method should render the right edge of the cell.
+   * @param forceTruncationSymbol - `true` if the rendered text should end with the truncation symbol even
+   * if the text fits. This is used when the cell is vertically truncated. If `false` the text should
+   * only include the truncation symbol if the text will not fit horizontally within the cell width.
+   * @param spanningCell - a number of if being called from a RowSpanCell. (how many rows below). otherwise undefined.
+   * @returns {String}
+   */
+  drawLine(lineNum, drawRight, forceTruncationSymbol, spanningCell) {
+    var left = this.chars[this.x == 0 ? 'left' : 'middle'];
+    if (this.x && spanningCell && this.cells) {
+      var cellLeft = this.cells[this.y + spanningCell][this.x - 1];
+      while (cellLeft instanceof ColSpanCell) {
+        cellLeft = this.cells[cellLeft.y][cellLeft.x - 1];
+      }
+      if (!(cellLeft instanceof RowSpanCell)) {
+        left = this.chars['rightMid'];
+      }
     }
-    if (!(cellLeft instanceof RowSpanCell)) {
-      left = this.chars['rightMid'];
-    }
+    var leftPadding = utils.repeat(' ', this.paddingLeft);
+    var right = drawRight ? this.chars['right'] : '';
+    var rightPadding = utils.repeat(' ', this.paddingRight);
+    var line = this.lines[lineNum];
+    var len = this.width - (this.paddingLeft + this.paddingRight);
+    if (forceTruncationSymbol) line += this.truncate || '…';
+    var content = utils.truncate(line, len, this.truncate);
+    content = utils.pad(content, len, ' ', this.hAlign);
+    content = leftPadding + content + rightPadding;
+    return this.stylizeLine(left, content, right);
   }
-  var leftPadding = utils.repeat(' ', this.paddingLeft);
-  var right = drawRight ? this.chars['right'] : '';
-  var rightPadding = utils.repeat(' ', this.paddingRight);
-  var line = this.lines[lineNum];
-  var len = this.width - (this.paddingLeft + this.paddingRight);
-  if (forceTruncationSymbol) line += this.truncate || '…';
-  var content = utils.truncate(line, len, this.truncate);
-  content = utils.pad(content, len, ' ', this.hAlign);
-  content = leftPadding + content + rightPadding;
-  return this.stylizeLine(left, content, right);
-};
 
-Cell.prototype.stylizeLine = function(left, content, right) {
-  left = this.wrapWithStyleColors('border', left);
-  right = this.wrapWithStyleColors('border', right);
-  if (this.y === 0) {
-    content = this.wrapWithStyleColors('head', content);
-  }
-  return left + content + right;
-};
-
-/**
- * Renders the bottom line of the cell.
- * @param drawRight - true if this method should render the right edge of the cell.
- * @returns {String}
- */
-Cell.prototype.drawBottom = function(drawRight) {
-  var left = this.chars[this.x == 0 ? 'bottomLeft' : 'bottomMid'];
-  var content = utils.repeat(this.chars.bottom, this.width);
-  var right = drawRight ? this.chars['bottomRight'] : '';
-  return this.wrapWithStyleColors('border', left + content + right);
-};
-
-/**
- * Renders a blank line of text within the cell. Used for top and/or bottom padding.
- * @param drawRight - true if this method should render the right edge of the cell.
- * @param spanningCell - a number of if being called from a RowSpanCell. (how many rows below). otherwise undefined.
- * @returns {String}
- */
-Cell.prototype.drawEmpty = function(drawRight, spanningCell) {
-  var left = this.chars[this.x == 0 ? 'left' : 'middle'];
-  if (this.x && spanningCell && this.cells) {
-    var cellLeft = this.cells[this.y + spanningCell][this.x - 1];
-    while (cellLeft instanceof ColSpanCell) {
-      cellLeft = this.cells[cellLeft.y][cellLeft.x - 1];
+  stylizeLine(left, content, right) {
+    left = this.wrapWithStyleColors('border', left);
+    right = this.wrapWithStyleColors('border', right);
+    if (this.y === 0) {
+      content = this.wrapWithStyleColors('head', content);
     }
-    if (!(cellLeft instanceof RowSpanCell)) {
-      left = this.chars['rightMid'];
-    }
+    return left + content + right;
   }
-  var right = drawRight ? this.chars['right'] : '';
-  var content = utils.repeat(' ', this.width);
-  return this.stylizeLine(left, content, right);
-};
+
+  /**
+   * Renders the bottom line of the cell.
+   * @param drawRight - true if this method should render the right edge of the cell.
+   * @returns {String}
+   */
+  drawBottom(drawRight) {
+    var left = this.chars[this.x == 0 ? 'bottomLeft' : 'bottomMid'];
+    var content = utils.repeat(this.chars.bottom, this.width);
+    var right = drawRight ? this.chars['bottomRight'] : '';
+    return this.wrapWithStyleColors('border', left + content + right);
+  }
+
+  /**
+   * Renders a blank line of text within the cell. Used for top and/or bottom padding.
+   * @param drawRight - true if this method should render the right edge of the cell.
+   * @param spanningCell - a number of if being called from a RowSpanCell. (how many rows below). otherwise undefined.
+   * @returns {String}
+   */
+  drawEmpty(drawRight, spanningCell) {
+    var left = this.chars[this.x == 0 ? 'left' : 'middle'];
+    if (this.x && spanningCell && this.cells) {
+      var cellLeft = this.cells[this.y + spanningCell][this.x - 1];
+      while (cellLeft instanceof ColSpanCell) {
+        cellLeft = this.cells[cellLeft.y][cellLeft.x - 1];
+      }
+      if (!(cellLeft instanceof RowSpanCell)) {
+        left = this.chars['rightMid'];
+      }
+    }
+    var right = drawRight ? this.chars['right'] : '';
+    var content = utils.repeat(' ', this.width);
+    return this.stylizeLine(left, content, right);
+  }
+}
 
 class ColSpanCell {
   /**

--- a/src/layout-manager.js
+++ b/src/layout-manager.js
@@ -1,8 +1,7 @@
-var kindOf = require('kind-of');
-var objectAssign = require('object-assign');
-var Cell = require('./cell');
-var RowSpanCell = Cell.RowSpanCell;
-var ColSpanCell = Cell.ColSpanCell;
+const kindOf = require('kind-of');
+const objectAssign = require('object-assign');
+const Cell = require('./cell');
+const { ColSpanCell, RowSpanCell } = Cell;
 
 (function() {
   function layoutTable(table) {
@@ -10,11 +9,11 @@ var ColSpanCell = Cell.ColSpanCell;
       row.forEach(function(cell, columnIndex) {
         cell.y = rowIndex;
         cell.x = columnIndex;
-        for (var y = rowIndex; y >= 0; y--) {
-          var row2 = table[y];
-          var xMax = y === rowIndex ? columnIndex : row2.length;
-          for (var x = 0; x < xMax; x++) {
-            var cell2 = row2[x];
+        for (let y = rowIndex; y >= 0; y--) {
+          let row2 = table[y];
+          let xMax = y === rowIndex ? columnIndex : row2.length;
+          for (let x = 0; x < xMax; x++) {
+            let cell2 = row2[x];
             while (cellsConflict(cell, cell2)) {
               cell.x++;
             }
@@ -25,7 +24,7 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function maxWidth(table) {
-    var mw = 0;
+    let mw = 0;
     table.forEach(function(row) {
       row.forEach(function(cell) {
         mw = Math.max(mw, cell.x + (cell.colSpan || 1));
@@ -39,27 +38,27 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function cellsConflict(cell1, cell2) {
-    var yMin1 = cell1.y;
-    var yMax1 = cell1.y - 1 + (cell1.rowSpan || 1);
-    var yMin2 = cell2.y;
-    var yMax2 = cell2.y - 1 + (cell2.rowSpan || 1);
-    var yConflict = !(yMin1 > yMax2 || yMin2 > yMax1);
+    let yMin1 = cell1.y;
+    let yMax1 = cell1.y - 1 + (cell1.rowSpan || 1);
+    let yMin2 = cell2.y;
+    let yMax2 = cell2.y - 1 + (cell2.rowSpan || 1);
+    let yConflict = !(yMin1 > yMax2 || yMin2 > yMax1);
 
-    var xMin1 = cell1.x;
-    var xMax1 = cell1.x - 1 + (cell1.colSpan || 1);
-    var xMin2 = cell2.x;
-    var xMax2 = cell2.x - 1 + (cell2.colSpan || 1);
-    var xConflict = !(xMin1 > xMax2 || xMin2 > xMax1);
+    let xMin1 = cell1.x;
+    let xMax1 = cell1.x - 1 + (cell1.colSpan || 1);
+    let xMin2 = cell2.x;
+    let xMax2 = cell2.x - 1 + (cell2.colSpan || 1);
+    let xConflict = !(xMin1 > xMax2 || xMin2 > xMax1);
 
     return yConflict && xConflict;
   }
 
   function conflictExists(rows, x, y) {
-    var i_max = Math.min(rows.length - 1, y);
-    var cell = { x: x, y: y };
-    for (var i = 0; i <= i_max; i++) {
-      var row = rows[i];
-      for (var j = 0; j < row.length; j++) {
+    let i_max = Math.min(rows.length - 1, y);
+    let cell = { x: x, y: y };
+    for (let i = 0; i <= i_max; i++) {
+      let row = rows[i];
+      for (let j = 0; j < row.length; j++) {
         if (cellsConflict(cell, row[j])) {
           return true;
         }
@@ -69,7 +68,7 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function allBlank(rows, y, xMin, xMax) {
-    for (var x = xMin; x < xMax; x++) {
+    for (let x = xMin; x < xMax; x++) {
       if (conflictExists(rows, x, y)) {
         return false;
       }
@@ -80,8 +79,8 @@ var ColSpanCell = Cell.ColSpanCell;
   function addRowSpanCells(table) {
     table.forEach(function(row, rowIndex) {
       row.forEach(function(cell) {
-        for (var i = 1; i < cell.rowSpan; i++) {
-          var rowSpanCell = new RowSpanCell(cell);
+        for (let i = 1; i < cell.rowSpan; i++) {
+          let rowSpanCell = new RowSpanCell(cell);
           rowSpanCell.x = cell.x;
           rowSpanCell.y = cell.y + i;
           rowSpanCell.colSpan = cell.colSpan;
@@ -92,12 +91,12 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function addColSpanCells(cellRows) {
-    for (var rowIndex = cellRows.length - 1; rowIndex >= 0; rowIndex--) {
-      var cellColumns = cellRows[rowIndex];
-      for (var columnIndex = 0; columnIndex < cellColumns.length; columnIndex++) {
-        var cell = cellColumns[columnIndex];
-        for (var k = 1; k < cell.colSpan; k++) {
-          var colSpanCell = new ColSpanCell();
+    for (let rowIndex = cellRows.length - 1; rowIndex >= 0; rowIndex--) {
+      let cellColumns = cellRows[rowIndex];
+      for (let columnIndex = 0; columnIndex < cellColumns.length; columnIndex++) {
+        let cell = cellColumns[columnIndex];
+        for (let k = 1; k < cell.colSpan; k++) {
+          let colSpanCell = new ColSpanCell();
           colSpanCell.x = cell.x + k;
           colSpanCell.y = cell.y;
           cellColumns.splice(columnIndex + 1, 0, colSpanCell);
@@ -107,7 +106,7 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function insertCell(cell, row) {
-    var x = 0;
+    let x = 0;
     while (x < row.length && row[x].x < cell.x) {
       x++;
     }
@@ -115,24 +114,24 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function fillInTable(table) {
-    var h_max = maxHeight(table);
-    var w_max = maxWidth(table);
-    for (var y = 0; y < h_max; y++) {
-      for (var x = 0; x < w_max; x++) {
+    let h_max = maxHeight(table);
+    let w_max = maxWidth(table);
+    for (let y = 0; y < h_max; y++) {
+      for (let x = 0; x < w_max; x++) {
         if (!conflictExists(table, x, y)) {
-          var opts = { x: x, y: y, colSpan: 1, rowSpan: 1 };
+          let opts = { x: x, y: y, colSpan: 1, rowSpan: 1 };
           x++;
           while (x < w_max && !conflictExists(table, x, y)) {
             opts.colSpan++;
             x++;
           }
-          var y2 = y + 1;
+          let y2 = y + 1;
           while (y2 < h_max && allBlank(table, y2, opts.x, opts.x + opts.colSpan)) {
             opts.rowSpan++;
             y2++;
           }
 
-          var cell = new Cell(opts);
+          let cell = new Cell(opts);
           cell.x = opts.x;
           cell.y = opts.y;
           insertCell(cell, table[y]);
@@ -144,7 +143,7 @@ var ColSpanCell = Cell.ColSpanCell;
   function generateCells(rows) {
     return rows.map(function(row) {
       if (kindOf(row) !== 'array') {
-        var key = Object.keys(row)[0];
+        let key = Object.keys(row)[0];
         row = row[key];
         if (kindOf(row) === 'array') {
           row = row.slice();
@@ -160,7 +159,7 @@ var ColSpanCell = Cell.ColSpanCell;
   }
 
   function makeTableLayout(rows) {
-    var cellRows = generateCells(rows);
+    let cellRows = generateCells(rows);
     layoutTable(cellRows);
     fillInTable(cellRows);
     addRowSpanCells(cellRows);
@@ -181,8 +180,8 @@ var ColSpanCell = Cell.ColSpanCell;
 
 function makeComputeWidths(colSpan, desiredWidth, x, forcedMin) {
   return function(vals, table) {
-    var result = [];
-    var spanners = [];
+    let result = [];
+    let spanners = [];
     table.forEach(function(row) {
       row.forEach(function(cell) {
         if ((cell[colSpan] || 1) > 1) {
@@ -200,23 +199,23 @@ function makeComputeWidths(colSpan, desiredWidth, x, forcedMin) {
     });
 
     //spanners.forEach(function(cell){
-    for (var k = spanners.length - 1; k >= 0; k--) {
-      var cell = spanners[k];
-      var span = cell[colSpan];
-      var col = cell[x];
-      var existingWidth = result[col];
-      var editableCols = kindOf(vals[col]) === 'number' ? 0 : 1;
-      for (var i = 1; i < span; i++) {
+    for (let k = spanners.length - 1; k >= 0; k--) {
+      let cell = spanners[k];
+      let span = cell[colSpan];
+      let col = cell[x];
+      let existingWidth = result[col];
+      let editableCols = kindOf(vals[col]) === 'number' ? 0 : 1;
+      for (let i = 1; i < span; i++) {
         existingWidth += 1 + result[col + i];
         if (kindOf(vals[col + i]) !== 'number') {
           editableCols++;
         }
       }
       if (cell[desiredWidth] > existingWidth) {
-        i = 0;
+        let i = 0;
         while (editableCols > 0 && cell[desiredWidth] > existingWidth) {
           if (kindOf(vals[col + i]) !== 'number') {
-            var dif = Math.round((cell[desiredWidth] - existingWidth) / editableCols);
+            let dif = Math.round((cell[desiredWidth] - existingWidth) / editableCols);
             existingWidth += dif;
             result[col + i] += dif;
             editableCols--;
@@ -227,7 +226,7 @@ function makeComputeWidths(colSpan, desiredWidth, x, forcedMin) {
     }
 
     objectAssign(vals, result);
-    for (var j = 0; j < vals.length; j++) {
+    for (let j = 0; j < vals.length; j++) {
       vals[j] = Math.max(forcedMin, vals[j] || 0);
     }
   };

--- a/src/table.js
+++ b/src/table.js
@@ -1,5 +1,5 @@
-var utils = require('./utils');
-var tableLayout = require('./layout-manager');
+const utils = require('./utils');
+const tableLayout = require('./layout-manager');
 
 class Table extends Array {
   constructor(options) {
@@ -9,8 +9,8 @@ class Table extends Array {
   }
 
   toString() {
-    var array = this;
-    var headersPresent = this.options.head && this.options.head.length;
+    let array = this;
+    let headersPresent = this.options.head && this.options.head.length;
     if (headersPresent) {
       array = [this.options.head];
       if (this.length) {
@@ -20,7 +20,7 @@ class Table extends Array {
       this.options.style.head = [];
     }
 
-    var cells = tableLayout.makeTableLayout(array);
+    let cells = tableLayout.makeTableLayout(array);
 
     cells.forEach(function(row) {
       row.forEach(function(cell) {
@@ -37,17 +37,17 @@ class Table extends Array {
       }, this);
     }, this);
 
-    var result = [];
+    let result = [];
 
-    for (var rowIndex = 0; rowIndex < cells.length; rowIndex++) {
-      var row = cells[rowIndex];
-      var heightOfRow = this.options.rowHeights[rowIndex];
+    for (let rowIndex = 0; rowIndex < cells.length; rowIndex++) {
+      let row = cells[rowIndex];
+      let heightOfRow = this.options.rowHeights[rowIndex];
 
       if (rowIndex === 0 || !this.options.style.compact || (rowIndex == 1 && headersPresent)) {
         doDraw(row, 'top', result);
       }
 
-      for (var lineNum = 0; lineNum < heightOfRow; lineNum++) {
+      for (let lineNum = 0; lineNum < heightOfRow; lineNum++) {
         doDraw(row, lineNum, result);
       }
 
@@ -60,17 +60,17 @@ class Table extends Array {
   }
 
   get width() {
-    var str = this.toString().split('\n');
+    let str = this.toString().split('\n');
     return str[0].length;
   }
 }
 
 function doDraw(row, lineNum, result) {
-  var line = [];
+  let line = [];
   row.forEach(function(cell) {
     line.push(cell.draw(lineNum));
   });
-  var str = line.join('');
+  let str = line.join('');
   if (str.length) result.push(str);
 }
 

--- a/src/table.js
+++ b/src/table.js
@@ -1,62 +1,69 @@
 var utils = require('./utils');
 var tableLayout = require('./layout-manager');
 
-function Table(options) {
-  this.options = utils.mergeOptions(options);
+class Table extends Array {
+  constructor(options) {
+    super();
+
+    this.options = utils.mergeOptions(options);
+  }
+
+  toString() {
+    var array = this;
+    var headersPresent = this.options.head && this.options.head.length;
+    if (headersPresent) {
+      array = [this.options.head];
+      if (this.length) {
+        array.push.apply(array, this);
+      }
+    } else {
+      this.options.style.head = [];
+    }
+
+    var cells = tableLayout.makeTableLayout(array);
+
+    cells.forEach(function(row) {
+      row.forEach(function(cell) {
+        cell.mergeTableOptions(this.options, cells);
+      }, this);
+    }, this);
+
+    tableLayout.computeWidths(this.options.colWidths, cells);
+    tableLayout.computeHeights(this.options.rowHeights, cells);
+
+    cells.forEach(function(row) {
+      row.forEach(function(cell) {
+        cell.init(this.options);
+      }, this);
+    }, this);
+
+    var result = [];
+
+    for (var rowIndex = 0; rowIndex < cells.length; rowIndex++) {
+      var row = cells[rowIndex];
+      var heightOfRow = this.options.rowHeights[rowIndex];
+
+      if (rowIndex === 0 || !this.options.style.compact || (rowIndex == 1 && headersPresent)) {
+        doDraw(row, 'top', result);
+      }
+
+      for (var lineNum = 0; lineNum < heightOfRow; lineNum++) {
+        doDraw(row, lineNum, result);
+      }
+
+      if (rowIndex + 1 == cells.length) {
+        doDraw(row, 'bottom', result);
+      }
+    }
+
+    return result.join('\n');
+  }
+
+  get width() {
+    var str = this.toString().split('\n');
+    return str[0].length;
+  }
 }
-
-Table.prototype.__proto__ = Array.prototype;
-
-Table.prototype.toString = function() {
-  var array = this;
-  var headersPresent = this.options.head && this.options.head.length;
-  if (headersPresent) {
-    array = [this.options.head];
-    if (this.length) {
-      array.push.apply(array, this);
-    }
-  } else {
-    this.options.style.head = [];
-  }
-
-  var cells = tableLayout.makeTableLayout(array);
-
-  cells.forEach(function(row) {
-    row.forEach(function(cell) {
-      cell.mergeTableOptions(this.options, cells);
-    }, this);
-  }, this);
-
-  tableLayout.computeWidths(this.options.colWidths, cells);
-  tableLayout.computeHeights(this.options.rowHeights, cells);
-
-  cells.forEach(function(row) {
-    row.forEach(function(cell) {
-      cell.init(this.options);
-    }, this);
-  }, this);
-
-  var result = [];
-
-  for (var rowIndex = 0; rowIndex < cells.length; rowIndex++) {
-    var row = cells[rowIndex];
-    var heightOfRow = this.options.rowHeights[rowIndex];
-
-    if (rowIndex === 0 || !this.options.style.compact || (rowIndex == 1 && headersPresent)) {
-      doDraw(row, 'top', result);
-    }
-
-    for (var lineNum = 0; lineNum < heightOfRow; lineNum++) {
-      doDraw(row, lineNum, result);
-    }
-
-    if (rowIndex + 1 == cells.length) {
-      doDraw(row, 'bottom', result);
-    }
-  }
-
-  return result.join('\n');
-};
 
 function doDraw(row, lineNum, result) {
   var line = [];
@@ -66,10 +73,5 @@ function doDraw(row, lineNum, result) {
   var str = line.join('');
   if (str.length) result.push(str);
 }
-
-Table.prototype.__defineGetter__('width', function() {
-  var str = this.toString().split('\n');
-  return str[0].length;
-});
 
 module.exports = Table;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,14 +1,14 @@
-var objectAssign = require('object-assign');
-var stringWidth = require('string-width');
+const objectAssign = require('object-assign');
+const stringWidth = require('string-width');
 
 function codeRegex(capture) {
   return capture ? /\u001b\[((?:\d*;){0,5}\d*)m/g : /\u001b\[(?:\d*;){0,5}\d*m/g;
 }
 
 function strlen(str) {
-  var code = codeRegex();
-  var stripped = ('' + str).replace(code, '');
-  var split = stripped.split('\n');
+  let code = codeRegex();
+  let stripped = ('' + str).replace(code, '');
+  let split = stripped.split('\n');
   return split.reduce(function(memo, s) {
     return stringWidth(s) > memo ? stringWidth(s) : memo;
   }, 0);
@@ -19,29 +19,30 @@ function repeat(str, times) {
 }
 
 function pad(str, len, pad, dir) {
-  var length = strlen(str);
+  let length = strlen(str);
   if (len + 1 >= length) {
-    var padlen = len - length;
+    let padlen = len - length;
     switch (dir) {
-      case 'right':
+      case 'right': {
         str = repeat(pad, padlen) + str;
         break;
-
-      case 'center':
-        var right = Math.ceil(padlen / 2);
-        var left = padlen - right;
+      }
+      case 'center': {
+        let right = Math.ceil(padlen / 2);
+        let left = padlen - right;
         str = repeat(pad, left) + str + repeat(pad, right);
         break;
-
-      default:
+      }
+      default: {
         str = str + repeat(pad, padlen);
         break;
+      }
     }
   }
   return str;
 }
 
-var codeCache = {};
+let codeCache = {};
 
 function addToCodeCache(name, on, off) {
   on = '\u001b[' + on + 'm';
@@ -59,7 +60,7 @@ addToCodeCache('inverse', 7, 27);
 addToCodeCache('strikethrough', 9, 29);
 
 function updateState(state, controlChars) {
-  var controlCode = controlChars[1] ? parseInt(controlChars[1].split(';')[0]) : 0;
+  let controlCode = controlChars[1] ? parseInt(controlChars[1].split(';')[0]) : 0;
   if ((controlCode >= 30 && controlCode <= 39) || (controlCode >= 90 && controlCode <= 97)) {
     state.lastForegroundAdded = controlChars[0];
     return;
@@ -69,7 +70,7 @@ function updateState(state, controlChars) {
     return;
   }
   if (controlCode === 0) {
-    for (var i in state) {
+    for (let i in state) {
       /* istanbul ignore else */
       if (state.hasOwnProperty(i)) {
         delete state[i];
@@ -77,16 +78,16 @@ function updateState(state, controlChars) {
     }
     return;
   }
-  var info = codeCache[controlChars[0]];
+  let info = codeCache[controlChars[0]];
   if (info) {
     state[info.set] = info.to;
   }
 }
 
 function readState(line) {
-  var code = codeRegex(true);
-  var controlChars = code.exec(line);
-  var state = {};
+  let code = codeRegex(true);
+  let controlChars = code.exec(line);
+  let state = {};
   while (controlChars !== null) {
     updateState(state, controlChars);
     controlChars = code.exec(line);
@@ -95,8 +96,8 @@ function readState(line) {
 }
 
 function unwindState(state, ret) {
-  var lastBackgroundAdded = state.lastBackgroundAdded;
-  var lastForegroundAdded = state.lastForegroundAdded;
+  let lastBackgroundAdded = state.lastBackgroundAdded;
+  let lastForegroundAdded = state.lastForegroundAdded;
 
   delete state.lastBackgroundAdded;
   delete state.lastForegroundAdded;
@@ -118,8 +119,8 @@ function unwindState(state, ret) {
 }
 
 function rewindState(state, ret) {
-  var lastBackgroundAdded = state.lastBackgroundAdded;
-  var lastForegroundAdded = state.lastForegroundAdded;
+  let lastBackgroundAdded = state.lastBackgroundAdded;
+  let lastForegroundAdded = state.lastForegroundAdded;
 
   delete state.lastBackgroundAdded;
   delete state.lastForegroundAdded;
@@ -153,17 +154,17 @@ function truncateWidth(str, desiredLength) {
 }
 
 function truncateWidthWithAnsi(str, desiredLength) {
-  var code = codeRegex(true);
-  var split = str.split(codeRegex());
-  var splitIndex = 0;
-  var retLen = 0;
-  var ret = '';
-  var myArray;
-  var state = {};
+  let code = codeRegex(true);
+  let split = str.split(codeRegex());
+  let splitIndex = 0;
+  let retLen = 0;
+  let ret = '';
+  let myArray;
+  let state = {};
 
   while (retLen < desiredLength) {
     myArray = code.exec(str);
-    var toAdd = split[splitIndex];
+    let toAdd = split[splitIndex];
     splitIndex++;
     if (retLen + strlen(toAdd) > desiredLength) {
       toAdd = truncateWidth(toAdd, desiredLength - retLen);
@@ -185,13 +186,13 @@ function truncateWidthWithAnsi(str, desiredLength) {
 
 function truncate(str, desiredLength, truncateChar) {
   truncateChar = truncateChar || '…';
-  var lengthOfStr = strlen(str);
+  let lengthOfStr = strlen(str);
   if (lengthOfStr <= desiredLength) {
     return str;
   }
   desiredLength -= strlen(truncateChar);
 
-  var ret = truncateWidthWithAnsi(str, desiredLength);
+  let ret = truncateWidthWithAnsi(str, desiredLength);
 
   return ret + truncateChar;
 }
@@ -234,21 +235,21 @@ function defaultOptions() {
 function mergeOptions(options, defaults) {
   options = options || {};
   defaults = defaults || defaultOptions();
-  var ret = objectAssign({}, defaults, options);
+  let ret = objectAssign({}, defaults, options);
   ret.chars = objectAssign({}, defaults.chars, options.chars);
   ret.style = objectAssign({}, defaults.style, options.style);
   return ret;
 }
 
 function wordWrap(maxLength, input) {
-  var lines = [];
-  var split = input.split(/(\s+)/g);
-  var line = [];
-  var lineLength = 0;
-  var whitespace;
-  for (var i = 0; i < split.length; i += 2) {
-    var word = split[i];
-    var newLength = lineLength + strlen(word);
+  let lines = [];
+  let split = input.split(/(\s+)/g);
+  let line = [];
+  let lineLength = 0;
+  let whitespace;
+  for (let i = 0; i < split.length; i += 2) {
+    let word = split[i];
+    let newLength = lineLength + strlen(word);
     if (lineLength > 0 && whitespace) {
       newLength += whitespace.length;
     }
@@ -271,21 +272,21 @@ function wordWrap(maxLength, input) {
 }
 
 function multiLineWordWrap(maxLength, input) {
-  var output = [];
+  let output = [];
   input = input.split('\n');
-  for (var i = 0; i < input.length; i++) {
+  for (let i = 0; i < input.length; i++) {
     output.push.apply(output, wordWrap(maxLength, input[i]));
   }
   return output;
 }
 
 function colorizeLines(input) {
-  var state = {};
-  var output = [];
-  for (var i = 0; i < input.length; i++) {
-    var line = rewindState(state, input[i]);
+  let state = {};
+  let output = [];
+  for (let i = 0; i < input.length; i++) {
+    let line = rewindState(state, input[i]);
     state = readState(line);
-    var temp = objectAssign({}, state);
+    let temp = objectAssign({}, state);
     output.push(unwindState(temp, line));
   }
   return output;

--- a/test/cell-test.js
+++ b/test/cell-test.js
@@ -1,9 +1,8 @@
 describe('Cell', function() {
-  var colors = require('colors');
-  var Cell = require('../src/cell');
-  var RowSpanCell = Cell.RowSpanCell;
-  var ColSpanCell = Cell.ColSpanCell;
-  var mergeOptions = require('../src/utils').mergeOptions;
+  const colors = require('colors');
+  const Cell = require('../src/cell');
+  const { ColSpanCell, RowSpanCell } = Cell;
+  const { mergeOptions } = require('../src/utils');
 
   function defaultOptions() {
     //overwrite coloring of head and border by default for easier testing.
@@ -32,59 +31,59 @@ describe('Cell', function() {
 
   describe('constructor', function() {
     it('colSpan and rowSpan default to 1', function() {
-      var cell = new Cell();
+      let cell = new Cell();
       expect(cell.colSpan).toEqual(1);
       expect(cell.rowSpan).toEqual(1);
     });
 
     it('colSpan and rowSpan can be set via constructor', function() {
-      var cell = new Cell({ rowSpan: 2, colSpan: 3 });
+      let cell = new Cell({ rowSpan: 2, colSpan: 3 });
       expect(cell.rowSpan).toEqual(2);
       expect(cell.colSpan).toEqual(3);
     });
 
     it('content can be set as a string', function() {
-      var cell = new Cell('hello\nworld');
+      let cell = new Cell('hello\nworld');
       expect(cell.content).toEqual('hello\nworld');
     });
 
     it('content can be set as a options property', function() {
-      var cell = new Cell({ content: 'hello\nworld' });
+      let cell = new Cell({ content: 'hello\nworld' });
       expect(cell.content).toEqual('hello\nworld');
     });
 
     it('default content is an empty string', function() {
-      var cell = new Cell();
+      let cell = new Cell();
       expect(cell.content).toEqual('');
     });
 
     it('new Cell(null) will have empty string content', function() {
-      var cell = new Cell(null);
+      let cell = new Cell(null);
       expect(cell.content).toEqual('');
     });
 
     it('new Cell({content: null}) will have empty string content', function() {
-      var cell = new Cell({ content: null });
+      let cell = new Cell({ content: null });
       expect(cell.content).toEqual('');
     });
 
     it('new Cell(0) will have "0" as content', function() {
-      var cell = new Cell(0);
+      let cell = new Cell(0);
       expect(cell.content).toEqual('0');
     });
 
     it('new Cell({content: 0}) will have "0" as content', function() {
-      var cell = new Cell({ content: 0 });
+      let cell = new Cell({ content: 0 });
       expect(cell.content).toEqual('0');
     });
 
     it('new Cell(false) will have "false" as content', function() {
-      var cell = new Cell(false);
+      let cell = new Cell(false);
       expect(cell.content).toEqual('false');
     });
 
     it('new Cell({content: false}) will have "false" as content', function() {
-      var cell = new Cell({ content: false });
+      let cell = new Cell({ content: false });
       expect(cell.content).toEqual('false');
     });
   });
@@ -92,24 +91,24 @@ describe('Cell', function() {
   describe('mergeTableOptions', function() {
     describe('chars', function() {
       it('unset chars take on value of table', function() {
-        var cell = new Cell();
-        var tableOptions = defaultOptions();
+        let cell = new Cell();
+        let tableOptions = defaultOptions();
         cell.mergeTableOptions(tableOptions);
         expect(cell.chars).toEqual(defaultChars());
       });
 
       it('set chars override the value of table', function() {
-        var cell = new Cell({ chars: { bottomRight: '=' } });
+        let cell = new Cell({ chars: { bottomRight: '=' } });
         cell.mergeTableOptions(defaultOptions());
-        var chars = defaultChars();
+        let chars = defaultChars();
         chars.bottomRight = '=';
         expect(cell.chars).toEqual(chars);
       });
 
       it('hyphenated names will be converted to camel-case', function() {
-        var cell = new Cell({ chars: { 'bottom-left': '=' } });
+        let cell = new Cell({ chars: { 'bottom-left': '=' } });
         cell.mergeTableOptions(defaultOptions());
-        var chars = defaultChars();
+        let chars = defaultChars();
         chars.bottomLeft = '=';
         expect(cell.chars).toEqual(chars);
       });
@@ -117,13 +116,13 @@ describe('Cell', function() {
 
     describe('truncate', function() {
       it('if unset takes on value of table', function() {
-        var cell = new Cell();
+        let cell = new Cell();
         cell.mergeTableOptions(defaultOptions());
         expect(cell.truncate).toEqual('…');
       });
 
       it('if set overrides value of table', function() {
-        var cell = new Cell({ truncate: '...' });
+        let cell = new Cell({ truncate: '...' });
         cell.mergeTableOptions(defaultOptions());
         expect(cell.truncate).toEqual('...');
       });
@@ -131,12 +130,12 @@ describe('Cell', function() {
 
     describe('style.padding-left', function() {
       it('if unset will be copied from tableOptions.style', function() {
-        var cell = new Cell();
+        let cell = new Cell();
         cell.mergeTableOptions(defaultOptions());
         expect(cell.paddingLeft).toEqual(1);
 
         cell = new Cell();
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.style['padding-left'] = 2;
         cell.mergeTableOptions(tableOptions);
         expect(cell.paddingLeft).toEqual(2);
@@ -149,7 +148,7 @@ describe('Cell', function() {
       });
 
       it('if set will override tableOptions.style', function() {
-        var cell = new Cell({ style: { 'padding-left': 2 } });
+        let cell = new Cell({ style: { 'padding-left': 2 } });
         cell.mergeTableOptions(defaultOptions());
         expect(cell.paddingLeft).toEqual(2);
 
@@ -161,12 +160,12 @@ describe('Cell', function() {
 
     describe('style.padding-right', function() {
       it('if unset will be copied from tableOptions.style', function() {
-        var cell = new Cell();
+        let cell = new Cell();
         cell.mergeTableOptions(defaultOptions());
         expect(cell.paddingRight).toEqual(1);
 
         cell = new Cell();
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.style['padding-right'] = 2;
         cell.mergeTableOptions(tableOptions);
         expect(cell.paddingRight).toEqual(2);
@@ -179,7 +178,7 @@ describe('Cell', function() {
       });
 
       it('if set will override tableOptions.style', function() {
-        var cell = new Cell({ style: { 'padding-right': 2 } });
+        let cell = new Cell({ style: { 'padding-right': 2 } });
         cell.mergeTableOptions(defaultOptions());
         expect(cell.paddingRight).toEqual(2);
 
@@ -191,21 +190,21 @@ describe('Cell', function() {
 
     describe('desiredWidth', function() {
       it('content(hello) padding(1,1) == 7', function() {
-        var cell = new Cell('hello');
+        let cell = new Cell('hello');
         cell.mergeTableOptions(defaultOptions());
         expect(cell.desiredWidth).toEqual(7);
       });
 
       it('content(hi) padding(1,2) == 5', function() {
-        var cell = new Cell({ content: 'hi', style: { paddingRight: 2 } });
-        var tableOptions = defaultOptions();
+        let cell = new Cell({ content: 'hi', style: { paddingRight: 2 } });
+        let tableOptions = defaultOptions();
         cell.mergeTableOptions(tableOptions);
         expect(cell.desiredWidth).toEqual(5);
       });
 
       it('content(hi) padding(3,2) == 7', function() {
-        var cell = new Cell({ content: 'hi', style: { paddingLeft: 3, paddingRight: 2 } });
-        var tableOptions = defaultOptions();
+        let cell = new Cell({ content: 'hi', style: { paddingLeft: 3, paddingRight: 2 } });
+        let tableOptions = defaultOptions();
         cell.mergeTableOptions(tableOptions);
         expect(cell.desiredWidth).toEqual(7);
       });
@@ -213,19 +212,19 @@ describe('Cell', function() {
 
     describe('desiredHeight', function() {
       it('1 lines of text', function() {
-        var cell = new Cell('hi');
+        let cell = new Cell('hi');
         cell.mergeTableOptions(defaultOptions());
         expect(cell.desiredHeight).toEqual(1);
       });
 
       it('2 lines of text', function() {
-        var cell = new Cell('hi\nbye');
+        let cell = new Cell('hi\nbye');
         cell.mergeTableOptions(defaultOptions());
         expect(cell.desiredHeight).toEqual(2);
       });
 
       it('2 lines of text', function() {
-        var cell = new Cell('hi\nbye\nyo');
+        let cell = new Cell('hi\nbye\nyo');
         cell.mergeTableOptions(defaultOptions());
         expect(cell.desiredHeight).toEqual(3);
       });
@@ -235,9 +234,9 @@ describe('Cell', function() {
   describe('init', function() {
     describe('hAlign', function() {
       it('if unset takes colAlign value from tableOptions', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.colAligns = ['left', 'right', 'both'];
-        var cell = new Cell();
+        let cell = new Cell();
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -255,9 +254,9 @@ describe('Cell', function() {
       });
 
       it('if set overrides tableOptions', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.colAligns = ['left', 'right', 'both'];
-        var cell = new Cell({ hAlign: 'right' });
+        let cell = new Cell({ hAlign: 'right' });
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -277,9 +276,9 @@ describe('Cell', function() {
 
     describe('vAlign', function() {
       it('if unset takes rowAlign value from tableOptions', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.rowAligns = ['top', 'bottom', 'center'];
-        var cell = new Cell();
+        let cell = new Cell();
         cell.y = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -297,10 +296,10 @@ describe('Cell', function() {
       });
 
       it('if set overrides tableOptions', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.rowAligns = ['top', 'bottom', 'center'];
 
-        var cell = new Cell({ vAlign: 'bottom' });
+        let cell = new Cell({ vAlign: 'bottom' });
         cell.y = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -322,10 +321,10 @@ describe('Cell', function() {
 
     describe('width', function() {
       it('will match colWidth of x', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.colWidths = [5, 10, 15];
 
-        var cell = new Cell();
+        let cell = new Cell();
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -345,10 +344,10 @@ describe('Cell', function() {
       });
 
       it('will add colWidths if colSpan > 1 with wordWrap false', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.colWidths = [5, 10, 15];
 
-        var cell = new Cell({ colSpan: 2 });
+        let cell = new Cell({ colSpan: 2 });
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -368,11 +367,11 @@ describe('Cell', function() {
       });
 
       it('will add colWidths if colSpan > 1 with wordWrap true', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.colWidths = [5, 10, 15];
         tableOptions.wordWrap = true;
 
-        var cell = new Cell({ colSpan: 2 });
+        let cell = new Cell({ colSpan: 2 });
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -392,11 +391,11 @@ describe('Cell', function() {
       });
 
       it('will use multiple columns for wordWrap text when using colSpan and wordWrap together', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.colWidths = [7, 7, 17];
         tableOptions.wordWrap = true;
 
-        var cell = new Cell({ content: 'the quick brown fox', colSpan: 2 });
+        let cell = new Cell({ content: 'the quick brown fox', colSpan: 2 });
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -420,11 +419,11 @@ describe('Cell', function() {
       });
 
       it('will only use one column for wordWrap text when not using colSpan', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.colWidths = [7, 7, 7];
         tableOptions.wordWrap = true;
 
-        var cell = new Cell({ content: 'the quick brown fox' });
+        let cell = new Cell({ content: 'the quick brown fox' });
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -436,10 +435,10 @@ describe('Cell', function() {
 
     describe('height', function() {
       it('will match rowHeight of x', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.rowHeights = [5, 10, 15];
 
-        var cell = new Cell();
+        let cell = new Cell();
         cell.y = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -459,10 +458,10 @@ describe('Cell', function() {
       });
 
       it('will add rowHeights if rowSpan > 1', function() {
-        var tableOptions = defaultOptions();
+        let tableOptions = defaultOptions();
         tableOptions.rowHeights = [5, 10, 15];
 
-        var cell = new Cell({ rowSpan: 2 });
+        let cell = new Cell({ rowSpan: 2 });
         cell.y = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -483,7 +482,7 @@ describe('Cell', function() {
     });
 
     describe('drawRight', function() {
-      var tableOptions;
+      let tableOptions;
 
       beforeEach(function() {
         tableOptions = defaultOptions();
@@ -491,7 +490,7 @@ describe('Cell', function() {
       });
 
       it('col 1 of 3, with default colspan', function() {
-        var cell = new Cell();
+        let cell = new Cell();
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -499,7 +498,7 @@ describe('Cell', function() {
       });
 
       it('col 2 of 3, with default colspan', function() {
-        var cell = new Cell();
+        let cell = new Cell();
         cell.x = 1;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -507,7 +506,7 @@ describe('Cell', function() {
       });
 
       it('col 3 of 3, with default colspan', function() {
-        var cell = new Cell();
+        let cell = new Cell();
         cell.x = 2;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -515,7 +514,7 @@ describe('Cell', function() {
       });
 
       it('col 3 of 4, with default colspan', function() {
-        var cell = new Cell();
+        let cell = new Cell();
         cell.x = 2;
         tableOptions.colWidths = [20, 20, 20, 20];
         cell.mergeTableOptions(tableOptions);
@@ -524,7 +523,7 @@ describe('Cell', function() {
       });
 
       it('col 2 of 3, with colspan of 2', function() {
-        var cell = new Cell({ colSpan: 2 });
+        let cell = new Cell({ colSpan: 2 });
         cell.x = 1;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -532,7 +531,7 @@ describe('Cell', function() {
       });
 
       it('col 1 of 3, with colspan of 3', function() {
-        var cell = new Cell({ colSpan: 3 });
+        let cell = new Cell({ colSpan: 3 });
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -540,7 +539,7 @@ describe('Cell', function() {
       });
 
       it('col 1 of 3, with colspan of 2', function() {
-        var cell = new Cell({ colSpan: 2 });
+        let cell = new Cell({ colSpan: 2 });
         cell.x = 0;
         cell.mergeTableOptions(tableOptions);
         cell.init(tableOptions);
@@ -550,7 +549,7 @@ describe('Cell', function() {
   });
 
   describe('drawLine', function() {
-    var cell;
+    let cell;
 
     beforeEach(function() {
       cell = new Cell();
@@ -916,7 +915,7 @@ describe('Cell', function() {
   });
 
   describe('RowSpanCell', function() {
-    var original, tableOptions;
+    let original, tableOptions;
 
     beforeEach(function() {
       original = {
@@ -930,7 +929,7 @@ describe('Cell', function() {
     });
 
     it('drawing top of the next row', function() {
-      var spanner = new RowSpanCell(original);
+      let spanner = new RowSpanCell(original);
       spanner.x = 0;
       spanner.y = 1;
       spanner.init(tableOptions);
@@ -940,7 +939,7 @@ describe('Cell', function() {
     });
 
     it('drawing line 0 of the next row', function() {
-      var spanner = new RowSpanCell(original);
+      let spanner = new RowSpanCell(original);
       spanner.x = 0;
       spanner.y = 1;
       spanner.init(tableOptions);
@@ -950,7 +949,7 @@ describe('Cell', function() {
     });
 
     it('drawing line 1 of the next row', function() {
-      var spanner = new RowSpanCell(original);
+      let spanner = new RowSpanCell(original);
       spanner.x = 0;
       spanner.y = 1;
       spanner.init(tableOptions);
@@ -960,7 +959,7 @@ describe('Cell', function() {
     });
 
     it('drawing top of two rows below', function() {
-      var spanner = new RowSpanCell(original);
+      let spanner = new RowSpanCell(original);
       spanner.x = 0;
       spanner.y = 2;
       spanner.init(tableOptions);
@@ -970,7 +969,7 @@ describe('Cell', function() {
     });
 
     it('drawing line 0 of two rows below', function() {
-      var spanner = new RowSpanCell(original);
+      let spanner = new RowSpanCell(original);
       spanner.x = 0;
       spanner.y = 2;
       spanner.init(tableOptions);
@@ -980,7 +979,7 @@ describe('Cell', function() {
     });
 
     it('drawing line 1 of two rows below', function() {
-      var spanner = new RowSpanCell(original);
+      let spanner = new RowSpanCell(original);
       spanner.x = 0;
       spanner.y = 2;
       spanner.init(tableOptions);
@@ -990,7 +989,7 @@ describe('Cell', function() {
     });
 
     it('drawing bottom', function() {
-      var spanner = new RowSpanCell(original);
+      let spanner = new RowSpanCell(original);
       spanner.x = 0;
       spanner.y = 1;
       spanner.init(tableOptions);

--- a/test/example-tests.js
+++ b/test/example-tests.js
@@ -1,6 +1,6 @@
-var printExamples = require('../lib/print-example');
-var examples = require('../examples/col-and-row-span-examples');
-var usage = require('../examples/basic-usage-examples');
+const printExamples = require('../lib/print-example');
+const examples = require('../examples/col-and-row-span-examples');
+const usage = require('../examples/basic-usage-examples');
 
 printExamples.runTest('@api Usage', usage);
 printExamples.runTest('@api Table (examples)', examples);

--- a/test/layout-manager-test.js
+++ b/test/layout-manager-test.js
@@ -1,25 +1,23 @@
 describe('layout-manager', function() {
-  var layoutManager = require('../src/layout-manager');
-  var layoutTable = layoutManager.layoutTable;
-  var addRowSpanCells = layoutManager.addRowSpanCells;
-  var maxWidth = layoutManager.maxWidth;
-  var Cell = require('../src/cell');
-  var RowSpanCell = Cell.RowSpanCell;
+  const layoutManager = require('../src/layout-manager');
+  const { layoutTable, addRowSpanCells, maxWidth } = layoutManager;
+  const Cell = require('../src/cell');
+  const { RowSpanCell } = Cell;
 
   describe('layoutTable', function() {
     it('sets x and y', function() {
-      var table = [[{}, {}], [{}, {}]];
+      let table = [[{}, {}], [{}, {}]];
 
       layoutTable(table);
 
       expect(table).toEqual([[{ x: 0, y: 0 }, { x: 1, y: 0 }], [{ x: 0, y: 1 }, { x: 1, y: 1 }]]);
 
-      var w = maxWidth(table);
+      let w = maxWidth(table);
       expect(w).toEqual(2);
     });
 
     it('colSpan will push x values to the right', function() {
-      var table = [[{ colSpan: 2 }, {}], [{}, { colSpan: 2 }]];
+      let table = [[{ colSpan: 2 }, {}], [{}, { colSpan: 2 }]];
 
       layoutTable(table);
 
@@ -32,7 +30,7 @@ describe('layout-manager', function() {
     });
 
     it('rowSpan will push x values on cells below', function() {
-      var table = [[{ rowSpan: 2 }, {}], [{}]];
+      let table = [[{ rowSpan: 2 }, {}], [{}]];
 
       layoutTable(table);
 
@@ -42,7 +40,7 @@ describe('layout-manager', function() {
     });
 
     it('colSpan and rowSpan together', function() {
-      var table = [[{ rowSpan: 2, colSpan: 2 }, {}], [{}]];
+      let table = [[{ rowSpan: 2, colSpan: 2 }, {}], [{}]];
 
       layoutTable(table);
 
@@ -52,7 +50,7 @@ describe('layout-manager', function() {
     });
 
     it('complex layout', function() {
-      var table = [
+      let table = [
         [{ c: 'a' }, { c: 'b' }, { c: 'c', rowSpan: 3, colSpan: 2 }, { c: 'd' }],
         [{ c: 'e', rowSpan: 2, colSpan: 2 }, { c: 'f' }],
         [{ c: 'g' }],
@@ -73,7 +71,7 @@ describe('layout-manager', function() {
     });
 
     it('maxWidth of single element', function() {
-      var table = [[{}]];
+      let table = [[{}]];
       layoutTable(table);
       expect(maxWidth(table)).toEqual(1);
     });
@@ -81,7 +79,7 @@ describe('layout-manager', function() {
 
   describe('addRowSpanCells', function() {
     it('will insert a rowSpan cell - beginning of line', function() {
-      var table = [[{ x: 0, y: 0, rowSpan: 2 }, { x: 1, y: 0 }], [{ x: 1, y: 1 }]];
+      let table = [[{ x: 0, y: 0, rowSpan: 2 }, { x: 1, y: 0 }], [{ x: 1, y: 1 }]];
 
       addRowSpanCells(table);
 
@@ -92,7 +90,7 @@ describe('layout-manager', function() {
     });
 
     it('will insert a rowSpan cell - end of line', function() {
-      var table = [[{ x: 0, y: 0 }, { x: 1, y: 0, rowSpan: 2 }], [{ x: 0, y: 1 }]];
+      let table = [[{ x: 0, y: 0 }, { x: 1, y: 0, rowSpan: 2 }], [{ x: 0, y: 1 }]];
 
       addRowSpanCells(table);
 
@@ -103,7 +101,7 @@ describe('layout-manager', function() {
     });
 
     it('will insert a rowSpan cell - middle of line', function() {
-      var table = [[{ x: 0, y: 0 }, { x: 1, y: 0, rowSpan: 2 }, { x: 2, y: 0 }], [{ x: 0, y: 1 }, { x: 2, y: 1 }]];
+      let table = [[{ x: 0, y: 0 }, { x: 1, y: 0, rowSpan: 2 }, { x: 2, y: 0 }], [{ x: 0, y: 1 }, { x: 2, y: 1 }]];
 
       addRowSpanCells(table);
 
@@ -115,7 +113,7 @@ describe('layout-manager', function() {
     });
 
     it('will insert a rowSpan cell - multiple on the same line', function() {
-      var table = [
+      let table = [
         [{ x: 0, y: 0 }, { x: 1, y: 0, rowSpan: 2 }, { x: 2, y: 0, rowSpan: 2 }, { x: 3, y: 0 }],
         [{ x: 0, y: 1 }, { x: 3, y: 1 }],
       ];

--- a/test/original-cli-table-index-tests.js
+++ b/test/original-cli-table-index-tests.js
@@ -1,8 +1,8 @@
 describe('@api original-cli-table index tests', function() {
-  var Table = require('../src/table');
+  const Table = require('../src/table');
 
   it('test complete table', function() {
-    var table = new Table({
+    let table = new Table({
       head: ['Rel', 'Change', 'By', 'When'],
       style: {
         'padding-left': 1,
@@ -18,7 +18,7 @@ describe('@api original-cli-table index tests', function() {
       ['v0.1', 'Testing something cool', 'rauchg@gmail.com', '8 minutes ago']
     );
 
-    var expected = [
+    let expected = [
       '┌──────┬─────────────────────┬─────────────────────────┬─────────────────┐',
       '│ Rel  │ Change              │ By                      │ When            │',
       '├──────┼─────────────────────┼─────────────────────────┼─────────────────┤',
@@ -33,7 +33,7 @@ describe('@api original-cli-table index tests', function() {
   });
 
   it('test width property', function() {
-    var table = new Table({
+    let table = new Table({
       head: ['Cool'],
       style: {
         head: [],
@@ -45,11 +45,11 @@ describe('@api original-cli-table index tests', function() {
   });
 
   it('test vertical table output', function() {
-    var table = new Table({ style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] } }); // clear styles to prevent color output
+    let table = new Table({ style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] } }); // clear styles to prevent color output
 
     table.push({ 'v0.1': 'Testing something cool' }, { 'v0.1': 'Testing something cool' });
 
-    var expected = [
+    let expected = [
       '┌────┬──────────────────────┐',
       '│v0.1│Testing something cool│',
       '├────┼──────────────────────┤',
@@ -61,14 +61,14 @@ describe('@api original-cli-table index tests', function() {
   });
 
   it('test cross table output', function() {
-    var table = new Table({
+    let table = new Table({
       head: ['', 'Header 1', 'Header 2'],
       style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] },
     }); // clear styles to prevent color output
 
     table.push({ 'Header 3': ['v0.1', 'Testing something cool'] }, { 'Header 4': ['v0.1', 'Testing something cool'] });
 
-    var expected = [
+    let expected = [
       '┌────────┬────────┬──────────────────────┐',
       '│        │Header 1│Header 2              │',
       '├────────┼────────┼──────────────────────┤',
@@ -82,16 +82,16 @@ describe('@api original-cli-table index tests', function() {
   });
 
   it('test table colors', function() {
-    var table = new Table({
+    let table = new Table({
       head: ['Rel', 'By'],
       style: { head: ['red'], border: ['grey'] },
     });
 
-    /*var off = ''
+    /*let off = ''
         , red = ''
         , orange = ''
         , grey = ''*/
-    var off = '\u001b[39m',
+    let off = '\u001b[39m',
       red = '\u001b[31m',
       orange = '\u001b[38;5;221m',
       grey = '\u001b[90m',
@@ -103,7 +103,7 @@ describe('@api original-cli-table index tests', function() {
     // The output from cli-table2 will still look the same, but the border color is
     // toggled off and back on at the border of each cell.
 
-    /*var expected = [
+    /*let expected = [
           grey + '┌──────┬──────────────────┐' + off
         , grey + '│' + off + red + ' Rel  ' + off + grey + '│' + off + red + ' By               ' + off + grey + '│' + off
         , grey + '├──────┼──────────────────┤' + off
@@ -111,7 +111,7 @@ describe('@api original-cli-table index tests', function() {
         , grey + '└──────┴──────────────────┘' + off
       ];*/
 
-    var expected = [
+    let expected = [
       grey + '┌──────' + off + grey + '┬──────────────────┐' + off,
       grey + '│' + off + red + ' Rel  ' + off + grey + '│' + off + red + ' By               ' + off + grey + '│' + off,
       grey + '├──────' + off + grey + '┼──────────────────┤' + off,
@@ -123,7 +123,7 @@ describe('@api original-cli-table index tests', function() {
   });
 
   it('test custom chars', function() {
-    var table = new Table({
+    let table = new Table({
       chars: {
         top: '═',
         'top-mid': '╤',
@@ -146,7 +146,7 @@ describe('@api original-cli-table index tests', function() {
 
     table.push(['foo', 'bar', 'baz'], ['frob', 'bar', 'quuz']);
 
-    var expected = [
+    let expected = [
       '╔══════╤═════╤══════╗',
       '║ foo  │ bar │ baz  ║',
       '╟──────┼─────┼──────╢',
@@ -158,7 +158,7 @@ describe('@api original-cli-table index tests', function() {
   });
 
   it('test compact shortand', function() {
-    var table = new Table({
+    let table = new Table({
       style: {
         head: [],
         border: [],
@@ -168,13 +168,13 @@ describe('@api original-cli-table index tests', function() {
 
     table.push(['foo', 'bar', 'baz'], ['frob', 'bar', 'quuz']);
 
-    var expected = ['┌──────┬─────┬──────┐', '│ foo  │ bar │ baz  │', '│ frob │ bar │ quuz │', '└──────┴─────┴──────┘'];
+    let expected = ['┌──────┬─────┬──────┐', '│ foo  │ bar │ baz  │', '│ frob │ bar │ quuz │', '└──────┴─────┴──────┘'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
 
   it('test compact empty mid line', function() {
-    var table = new Table({
+    let table = new Table({
       chars: {
         mid: '',
         'left-mid': '',
@@ -189,13 +189,13 @@ describe('@api original-cli-table index tests', function() {
 
     table.push(['foo', 'bar', 'baz'], ['frob', 'bar', 'quuz']);
 
-    var expected = ['┌──────┬─────┬──────┐', '│ foo  │ bar │ baz  │', '│ frob │ bar │ quuz │', '└──────┴─────┴──────┘'];
+    let expected = ['┌──────┬─────┬──────┐', '│ foo  │ bar │ baz  │', '│ frob │ bar │ quuz │', '└──────┴─────┴──────┘'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
 
   it('test decoration lines disabled', function() {
-    var table = new Table({
+    let table = new Table({
       chars: {
         top: '',
         'top-mid': '',
@@ -223,13 +223,13 @@ describe('@api original-cli-table index tests', function() {
 
     table.push(['foo', 'bar', 'baz'], ['frobnicate', 'bar', 'quuz']);
 
-    var expected = ['foo        bar baz ', 'frobnicate bar quuz'];
+    let expected = ['foo        bar baz ', 'frobnicate bar quuz'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
 
   it('test with null/undefined as values or column names', function() {
-    var table = new Table({
+    let table = new Table({
       style: {
         head: [],
         border: [],
@@ -242,13 +242,13 @@ describe('@api original-cli-table index tests', function() {
     // The empty columns have widths based on the strings `null` and `undefined`
     // That does not make sense to me, so I am deviating from the original behavior here.
 
-    /*var expected = [
+    /*let expected = [
           '┌──────┬───────────┬───┐'
         , '│      │           │ 0 │'
         , '└──────┴───────────┴───┘'
       ];  */
 
-    var expected = ['┌──┬──┬───┐', '│  │  │ 0 │', '└──┴──┴───┘'];
+    let expected = ['┌──┬──┬───┐', '│  │  │ 0 │', '└──┴──┴───┘'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });

--- a/test/original-cli-table-newlines-test.js
+++ b/test/original-cli-table-newlines-test.js
@@ -1,8 +1,8 @@
 describe('@api original-cli-table newline tests', function() {
-  var Table = require('../src/table');
+  const Table = require('../src/table');
 
   it('test table with newlines in headers', function() {
-    var table = new Table({
+    let table = new Table({
       head: ['Test', '1\n2\n3'],
       style: {
         'padding-left': 1,
@@ -12,45 +12,45 @@ describe('@api original-cli-table newline tests', function() {
       },
     });
 
-    var expected = ['┌──────┬───┐', '│ Test │ 1 │', '│      │ 2 │', '│      │ 3 │', '└──────┴───┘'];
+    let expected = ['┌──────┬───┐', '│ Test │ 1 │', '│      │ 2 │', '│      │ 3 │', '└──────┴───┘'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
 
   it('test column width is accurately reflected when newlines are present', function() {
-    var table = new Table({ head: ['Test\nWidth'], style: { head: [], border: [] } });
+    let table = new Table({ head: ['Test\nWidth'], style: { head: [], border: [] } });
     expect(table.width).toEqual(9);
   });
 
   it('test newlines in body cells', function() {
-    var table = new Table({ style: { head: [], border: [] } });
+    let table = new Table({ style: { head: [], border: [] } });
 
     table.push(['something\nwith\nnewlines']);
 
-    var expected = ['┌───────────┐', '│ something │', '│ with      │', '│ newlines  │', '└───────────┘'];
+    let expected = ['┌───────────┐', '│ something │', '│ with      │', '│ newlines  │', '└───────────┘'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
 
   it('test newlines in vertical cell header and body', function() {
-    var table = new Table({ style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] } });
+    let table = new Table({ style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] } });
 
     table.push({ 'v\n0.1': 'Testing\nsomething cool' });
 
-    var expected = ['┌───┬──────────────┐', '│v  │Testing       │', '│0.1│something cool│', '└───┴──────────────┘'];
+    let expected = ['┌───┬──────────────┐', '│v  │Testing       │', '│0.1│something cool│', '└───┴──────────────┘'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
 
   it('test newlines in cross table header and body', function() {
-    var table = new Table({
+    let table = new Table({
       head: ['', 'Header\n1'],
       style: { 'padding-left': 0, 'padding-right': 0, head: [], border: [] },
     });
 
     table.push({ 'Header\n2': ['Testing\nsomething\ncool'] });
 
-    var expected = [
+    let expected = [
       '┌──────┬─────────┐',
       '│      │Header   │',
       '│      │1        │',

--- a/test/table-layout-test.js
+++ b/test/table-layout-test.js
@@ -1,68 +1,64 @@
 describe('tableLayout', function() {
-  var Cell = require('../src/cell');
-  var layoutManager = require('../src/layout-manager');
-  var makeTableLayout = layoutManager.makeTableLayout;
-  var addRowSpanCells = layoutManager.addRowSpanCells;
-  var fillInTable = layoutManager.fillInTable;
-  var computeWidths = layoutManager.computeWidths;
-  var computeHeights = layoutManager.computeHeights;
-  var kindOf = require('kind-of');
+  const Cell = require('../src/cell');
+  const layoutManager = require('../src/layout-manager');
+  const { makeTableLayout, addRowSpanCells, fillInTable, computeWidths, computeHeights } = layoutManager;
+  const kindOf = require('kind-of');
 
   it('simple 2x2 layout', function() {
-    var actual = makeTableLayout([['hello', 'goodbye'], ['hola', 'adios']]);
+    let actual = makeTableLayout([['hello', 'goodbye'], ['hola', 'adios']]);
 
-    var expected = [['hello', 'goodbye'], ['hola', 'adios']];
+    let expected = [['hello', 'goodbye'], ['hola', 'adios']];
 
     checkLayout(actual, expected);
   });
 
   it('cross table', function() {
-    var actual = makeTableLayout([{ '1.0': ['yes', 'no'] }, { '2.0': ['hello', 'goodbye'] }]);
+    let actual = makeTableLayout([{ '1.0': ['yes', 'no'] }, { '2.0': ['hello', 'goodbye'] }]);
 
-    var expected = [['1.0', 'yes', 'no'], ['2.0', 'hello', 'goodbye']];
+    let expected = [['1.0', 'yes', 'no'], ['2.0', 'hello', 'goodbye']];
 
     checkLayout(actual, expected);
   });
 
   it('vertical table', function() {
-    var actual = makeTableLayout([{ '1.0': 'yes' }, { '2.0': 'hello' }]);
+    let actual = makeTableLayout([{ '1.0': 'yes' }, { '2.0': 'hello' }]);
 
-    var expected = [['1.0', 'yes'], ['2.0', 'hello']];
+    let expected = [['1.0', 'yes'], ['2.0', 'hello']];
 
     checkLayout(actual, expected);
   });
 
   it('colSpan adds RowSpanCells to the right', function() {
-    var actual = makeTableLayout([[{ content: 'hello', colSpan: 2 }], ['hola', 'adios']]);
+    let actual = makeTableLayout([[{ content: 'hello', colSpan: 2 }], ['hola', 'adios']]);
 
-    var expected = [[{ content: 'hello', colSpan: 2 }, null], ['hola', 'adios']];
+    let expected = [[{ content: 'hello', colSpan: 2 }, null], ['hola', 'adios']];
 
     checkLayout(actual, expected);
   });
 
   it('rowSpan adds RowSpanCell below', function() {
-    var actual = makeTableLayout([[{ content: 'hello', rowSpan: 2 }, 'goodbye'], ['adios']]);
+    let actual = makeTableLayout([[{ content: 'hello', rowSpan: 2 }, 'goodbye'], ['adios']]);
 
-    var expected = [['hello', 'goodbye'], [{ spannerFor: [0, 0] }, 'adios']];
+    let expected = [['hello', 'goodbye'], [{ spannerFor: [0, 0] }, 'adios']];
 
     checkLayout(actual, expected);
   });
 
   it('rowSpan and cellSpan together', function() {
-    var actual = makeTableLayout([[{ content: 'hello', rowSpan: 2, colSpan: 2 }, 'goodbye'], ['adios']]);
+    let actual = makeTableLayout([[{ content: 'hello', rowSpan: 2, colSpan: 2 }, 'goodbye'], ['adios']]);
 
-    var expected = [['hello', null, 'goodbye'], [{ spannerFor: [0, 0] }, null, 'adios']];
+    let expected = [['hello', null, 'goodbye'], [{ spannerFor: [0, 0] }, null, 'adios']];
 
     checkLayout(actual, expected);
   });
 
   it('complex layout', function() {
-    var actual = makeTableLayout([
+    let actual = makeTableLayout([
       [{ content: 'hello', rowSpan: 2, colSpan: 2 }, { content: 'yo', rowSpan: 2, colSpan: 2 }, 'goodbye'],
       ['adios'],
     ]);
 
-    var expected = [
+    let expected = [
       ['hello', null, 'yo', null, 'goodbye'],
       [{ spannerFor: [0, 0] }, null, { spannerFor: [0, 2] }, null, 'adios'],
     ];
@@ -71,13 +67,13 @@ describe('tableLayout', function() {
   });
 
   it('complex layout2', function() {
-    var actual = makeTableLayout([
+    let actual = makeTableLayout([
       ['a', 'b', { content: 'c', rowSpan: 3, colSpan: 2 }, 'd'],
       [{ content: 'e', rowSpan: 2, colSpan: 2 }, 'f'],
       ['g'],
     ]);
 
-    var expected = [
+    let expected = [
       ['a', 'b', 'c', null, 'd'],
       ['e', null, { spannerFor: [0, 2] }, null, 'f'],
       [{ spannerFor: [1, 0] }, null, { spannerFor: [0, 2] }, null, 'g'],
@@ -87,9 +83,9 @@ describe('tableLayout', function() {
   });
 
   it('stairstep spans', function() {
-    var actual = makeTableLayout([[{ content: '', rowSpan: 2 }, ''], [{ content: '', rowSpan: 2 }], ['']]);
+    let actual = makeTableLayout([[{ content: '', rowSpan: 2 }, ''], [{ content: '', rowSpan: 2 }], ['']]);
 
-    var expected = [
+    let expected = [
       [{ content: '', rowSpan: 2 }, ''],
       [{ spannerFor: [0, 0] }, { content: '', rowSpan: 2 }],
       ['', { spannerFor: [1, 1] }],
@@ -100,28 +96,28 @@ describe('tableLayout', function() {
 
   describe('fillInTable', function() {
     function mc(opts, y, x) {
-      var cell = new Cell(opts);
+      let cell = new Cell(opts);
       cell.x = x;
       cell.y = y;
       return cell;
     }
 
     it('will blank out individual cells', function() {
-      var cells = [[mc('a', 0, 1)], [mc('b', 1, 0)]];
+      let cells = [[mc('a', 0, 1)], [mc('b', 1, 0)]];
       fillInTable(cells);
 
       checkLayout(cells, [['', 'a'], ['b', '']]);
     });
 
     it('will autospan to the right', function() {
-      var cells = [[], [mc('a', 1, 1)]];
+      let cells = [[], [mc('a', 1, 1)]];
       fillInTable(cells);
 
       checkLayout(cells, [[{ content: '', colSpan: 2 }, null], ['', 'a']]);
     });
 
     it('will autospan down', function() {
-      var cells = [[mc('a', 0, 1)], []];
+      let cells = [[mc('a', 0, 1)], []];
       fillInTable(cells);
       addRowSpanCells(cells);
 
@@ -129,7 +125,7 @@ describe('tableLayout', function() {
     });
 
     it('will autospan right and down', function() {
-      var cells = [[mc('a', 0, 2)], [], [mc('b', 2, 1)]];
+      let cells = [[mc('a', 0, 2)], [], [mc('b', 2, 1)]];
       fillInTable(cells);
       addRowSpanCells(cells);
 
@@ -147,8 +143,8 @@ describe('tableLayout', function() {
     }
 
     it('finds the maximum desired width of each column', function() {
-      var widths = [];
-      var cells = [
+      let widths = [];
+      let cells = [
         [mc(0, 0, 7), mc(0, 1, 3), mc(0, 2, 5)],
         [mc(1, 0, 8), mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 6), mc(2, 1, 9), mc(2, 2, 1)],
@@ -160,8 +156,8 @@ describe('tableLayout', function() {
     });
 
     it("won't touch hard coded values", function() {
-      var widths = [null, 3];
-      var cells = [
+      let widths = [null, 3];
+      let cells = [
         [mc(0, 0, 7), mc(0, 1, 3), mc(0, 2, 5)],
         [mc(1, 0, 8), mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 6), mc(2, 1, 9), mc(2, 2, 1)],
@@ -173,15 +169,15 @@ describe('tableLayout', function() {
     });
 
     it('assumes undefined desiredWidth is 1', function() {
-      var widths = [];
-      var cells = [[{ x: 0, y: 0 }], [{ x: 0, y: 1 }], [{ x: 0, y: 2 }]];
+      let widths = [];
+      let cells = [[{ x: 0, y: 0 }], [{ x: 0, y: 1 }], [{ x: 0, y: 2 }]];
       computeWidths(widths, cells);
       expect(widths).toEqual([1]);
     });
 
     it('takes into account colSpan and wont over expand', function() {
-      var widths = [];
-      var cells = [
+      let widths = [];
+      let cells = [
         [mc(0, 0, 10, 2), mc(0, 2, 5)],
         [mc(1, 0, 5), mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)],
@@ -191,8 +187,8 @@ describe('tableLayout', function() {
     });
 
     it('will expand rows involved in colSpan in a balanced way', function() {
-      var widths = [];
-      var cells = [
+      let widths = [];
+      let cells = [
         [mc(0, 0, 13, 2), mc(0, 2, 5)],
         [mc(1, 0, 5), mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)],
@@ -202,29 +198,29 @@ describe('tableLayout', function() {
     });
 
     it('expands across 3 cols', function() {
-      var widths = [];
-      var cells = [[mc(0, 0, 25, 3)], [mc(1, 0, 5), mc(1, 1, 5), mc(1, 2, 2)], [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)]];
+      let widths = [];
+      let cells = [[mc(0, 0, 25, 3)], [mc(1, 0, 5), mc(1, 1, 5), mc(1, 2, 2)], [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)]];
       computeWidths(widths, cells);
       expect(widths).toEqual([9, 9, 5]);
     });
 
     it('multiple spans in same table', function() {
-      var widths = [];
-      var cells = [[mc(0, 0, 25, 3)], [mc(1, 0, 30, 3)], [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)]];
+      let widths = [];
+      let cells = [[mc(0, 0, 25, 3)], [mc(1, 0, 30, 3)], [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)]];
       computeWidths(widths, cells);
       expect(widths).toEqual([11, 9, 8]);
     });
 
     it('spans will only edit uneditable tables', function() {
-      var widths = [null, 3];
-      var cells = [[mc(0, 0, 20, 3)], [mc(1, 0, 4), mc(1, 1, 20), mc(1, 2, 5)]];
+      let widths = [null, 3];
+      let cells = [[mc(0, 0, 20, 3)], [mc(1, 0, 4), mc(1, 1, 20), mc(1, 2, 5)]];
       computeWidths(widths, cells);
       expect(widths).toEqual([7, 3, 8]);
     });
 
     it('spans will only edit uneditable tables - first column uneditable', function() {
-      var widths = [3];
-      var cells = [[mc(0, 0, 20, 3)], [mc(1, 0, 4), mc(1, 1, 3), mc(1, 2, 5)]];
+      let widths = [3];
+      let cells = [[mc(0, 0, 20, 3)], [mc(1, 0, 4), mc(1, 1, 3), mc(1, 2, 5)]];
       computeWidths(widths, cells);
       expect(widths).toEqual([3, 7, 8]);
     });
@@ -236,8 +232,8 @@ describe('tableLayout', function() {
     }
 
     it('finds the maximum desired height of each row', function() {
-      var heights = [];
-      var cells = [
+      let heights = [];
+      let cells = [
         [mc(0, 0, 7), mc(0, 1, 3), mc(0, 2, 5)],
         [mc(1, 0, 8), mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 6), mc(2, 1, 9), mc(2, 2, 1)],
@@ -249,8 +245,8 @@ describe('tableLayout', function() {
     });
 
     it("won't touch hard coded values", function() {
-      var heights = [null, 3];
-      var cells = [
+      let heights = [null, 3];
+      let cells = [
         [mc(0, 0, 7), mc(0, 1, 3), mc(0, 2, 5)],
         [mc(1, 0, 8), mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 6), mc(2, 1, 9), mc(2, 2, 1)],
@@ -262,15 +258,15 @@ describe('tableLayout', function() {
     });
 
     it('assumes undefined desiredHeight is 1', function() {
-      var heights = [];
-      var cells = [[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 }]];
+      let heights = [];
+      let cells = [[{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 }]];
       computeHeights(heights, cells);
       expect(heights).toEqual([1]);
     });
 
     it('takes into account rowSpan and wont over expand', function() {
-      var heights = [];
-      var cells = [
+      let heights = [];
+      let cells = [
         [mc(0, 0, 10, 2), mc(0, 1, 5), mc(0, 2, 2)],
         [mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)],
@@ -280,8 +276,8 @@ describe('tableLayout', function() {
     });
 
     it('will expand rows involved in rowSpan in a balanced way', function() {
-      var heights = [];
-      var cells = [
+      let heights = [];
+      let cells = [
         [mc(0, 0, 13, 2), mc(0, 1, 5), mc(0, 2, 5)],
         [mc(1, 1, 5), mc(1, 2, 2)],
         [mc(2, 0, 4), mc(2, 1, 2), mc(2, 2, 1)],
@@ -291,15 +287,15 @@ describe('tableLayout', function() {
     });
 
     it('expands across 3 rows', function() {
-      var heights = [];
-      var cells = [[mc(0, 0, 25, 3), mc(0, 1, 5), mc(0, 2, 4)], [mc(1, 1, 5), mc(1, 2, 2)], [mc(2, 1, 2), mc(2, 2, 1)]];
+      let heights = [];
+      let cells = [[mc(0, 0, 25, 3), mc(0, 1, 5), mc(0, 2, 4)], [mc(1, 1, 5), mc(1, 2, 2)], [mc(2, 1, 2), mc(2, 2, 1)]];
       computeHeights(heights, cells);
       expect(heights).toEqual([9, 9, 5]);
     });
 
     it('multiple spans in same table', function() {
-      var heights = [];
-      var cells = [[mc(0, 0, 25, 3), mc(0, 1, 30, 3), mc(0, 2, 4)], [mc(1, 2, 2)], [mc(2, 2, 1)]];
+      let heights = [];
+      let cells = [[mc(0, 0, 25, 3), mc(0, 1, 30, 3), mc(0, 2, 4)], [mc(1, 2, 2)], [mc(2, 2, 1)]];
       computeHeights(heights, cells);
       expect(heights).toEqual([11, 9, 8]);
     });
@@ -329,7 +325,7 @@ describe('tableLayout', function() {
     expectedTable.forEach(function(expectedRow, y) {
       expectedRow.forEach(function(expectedCell, x) {
         if (expectedCell !== null) {
-          var actualCell = findCell(actualTable, x, y);
+          let actualCell = findCell(actualTable, x, y);
           checkExpectation(actualCell, expectedCell, x, y, actualTable);
         }
       });
@@ -337,10 +333,10 @@ describe('tableLayout', function() {
   }
 
   function findCell(table, x, y) {
-    for (var i = 0; i < table.length; i++) {
-      var row = table[i];
-      for (var j = 0; j < row.length; j++) {
-        var cell = row[j];
+    for (let i = 0; i < table.length; i++) {
+      let row = table[i];
+      for (let j = 0; j < row.length; j++) {
+        let cell = row[j];
         if (cell.x === x && cell.y === y) {
           return cell;
         }

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1,13 +1,13 @@
 describe('@api Table ', function() {
-  var Table = require('..');
-  var colors = require('colors/safe');
+  const Table = require('..');
+  const colors = require('colors/safe');
 
   it('wordWrap with colored text', function() {
-    var table = new Table({ style: { border: [], head: [] }, wordWrap: true, colWidths: [7, 9] });
+    let table = new Table({ style: { border: [], head: [] }, wordWrap: true, colWidths: [7, 9] });
 
     table.push([colors.red('Hello how are you?'), colors.blue('I am fine thanks!')]);
 
-    var expected = [
+    let expected = [
       '┌───────┬─────────┐',
       '│ ' + colors.red('Hello') + ' │ ' + colors.blue('I am') + '    │',
       '│ ' + colors.red('how') + '   │ ' + colors.blue('fine') + '    │',
@@ -20,17 +20,17 @@ describe('@api Table ', function() {
   });
 
   it('allows numbers as `content` property of cells defined using object notation', function() {
-    var table = new Table({ style: { border: [], head: [] } });
+    let table = new Table({ style: { border: [], head: [] } });
 
     table.push([{ content: 12 }]);
 
-    var expected = ['┌────┐', '│ 12 │', '└────┘'];
+    let expected = ['┌────┐', '│ 12 │', '└────┘'];
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
 
   it('throws if content is not a string or number', function() {
-    var table = new Table({ style: { border: [], head: [] } });
+    let table = new Table({ style: { border: [], head: [] } });
 
     expect(function() {
       table.push([{ content: { a: 'b' } }]);
@@ -39,7 +39,7 @@ describe('@api Table ', function() {
   });
 
   it('works with CJK values', function() {
-    var table = new Table({ style: { border: [], head: [] }, colWidths: [5, 10, 5] });
+    let table = new Table({ style: { border: [], head: [] }, colWidths: [5, 10, 5] });
 
     table.push(
       ['foobar', 'English test', 'baz'],
@@ -48,7 +48,7 @@ describe('@api Table ', function() {
       ['foobar', '한국어테스트', 'baz']
     );
 
-    var expected = [
+    let expected = [
       '┌─────┬──────────┬─────┐',
       '│ fo… │ English… │ baz │',
       '├─────┼──────────┼─────┤',
@@ -66,7 +66,7 @@ describe('@api Table ', function() {
 
 /*
 
- var expected = [
+ let expected = [
    '┌──┬───┬──┬──┐'
  , '│  │   │  │  │'
  , '├──┼───┼──┼──┤'

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,13 +1,8 @@
 describe('utils', function() {
-  var colors = require('colors/safe');
-  var utils = require('../src/utils');
+  const colors = require('colors/safe');
+  const utils = require('../src/utils');
 
-  var strlen = utils.strlen;
-  var repeat = utils.repeat;
-  var pad = utils.pad;
-  var truncate = utils.truncate;
-  var mergeOptions = utils.mergeOptions;
-  var wordWrap = utils.wordWrap;
+  const { strlen, repeat, pad, truncate, mergeOptions, wordWrap } = utils;
 
   describe('strlen', function() {
     it('length of "hello" is 5', function() {
@@ -105,61 +100,61 @@ describe('utils', function() {
     });
 
     it('truncate(colors.zebra("goodnight moon"), 15, "…") == colors.zebra("goodnight moon")', function() {
-      var original = colors.zebra('goodnight moon');
+      let original = colors.zebra('goodnight moon');
       expect(truncate(original, 15, '…')).toEqual(original);
     });
 
     it('truncate(colors.zebra("goodnight moon"), 8, "…") == colors.zebra("goodnig") + "…"', function() {
-      var original = colors.zebra('goodnight moon');
-      var expected = colors.zebra('goodnig') + '…';
+      let original = colors.zebra('goodnight moon');
+      let expected = colors.zebra('goodnig') + '…';
       expect(truncate(original, 8, '…')).toEqual(expected);
     });
 
     it('truncate(colors.zebra("goodnight moon"), 9, "…") == colors.zebra("goodnig") + "…"', function() {
-      var original = colors.zebra('goodnight moon');
-      var expected = colors.zebra('goodnigh') + '…';
+      let original = colors.zebra('goodnight moon');
+      let expected = colors.zebra('goodnigh') + '…';
       expect(truncate(original, 9, '…')).toEqual(expected);
     });
 
     it('red(hello) + green(world) truncated to 9 chars', function() {
-      var original = colors.red('hello') + colors.green(' world');
-      var expected = colors.red('hello') + colors.green(' wo') + '…';
+      let original = colors.red('hello') + colors.green(' world');
+      let expected = colors.red('hello') + colors.green(' wo') + '…';
       expect(truncate(original, 9)).toEqual(expected);
     });
 
     it('red-on-green(hello) + green-on-red(world) truncated to 9 chars', function() {
-      var original = colors.red.bgGreen('hello') + colors.green.bgRed(' world');
-      var expected = colors.red.bgGreen('hello') + colors.green.bgRed(' wo') + '…';
+      let original = colors.red.bgGreen('hello') + colors.green.bgRed(' world');
+      let expected = colors.red.bgGreen('hello') + colors.green.bgRed(' wo') + '…';
       expect(truncate(original, 9)).toEqual(expected);
     });
 
     it('red-on-green(hello) + green-on-red(world) truncated to 10 chars - using inverse', function() {
-      var original = colors.red.bgGreen('hello' + colors.inverse(' world'));
-      var expected = colors.red.bgGreen('hello' + colors.inverse(' wor')) + '…';
+      let original = colors.red.bgGreen('hello' + colors.inverse(' world'));
+      let expected = colors.red.bgGreen('hello' + colors.inverse(' wor')) + '…';
       expect(truncate(original, 10)).toEqual(expected);
     });
 
     it('red-on-green( zebra (hello world) ) truncated to 11 chars', function() {
-      var original = colors.red.bgGreen(colors.zebra('hello world'));
-      var expected = colors.red.bgGreen(colors.zebra('hello world'));
+      let original = colors.red.bgGreen(colors.zebra('hello world'));
+      let expected = colors.red.bgGreen(colors.zebra('hello world'));
       expect(truncate(original, 11)).toEqual(expected);
     });
 
     it('red-on-green( zebra (hello world) ) truncated to 10 chars', function() {
-      var original = colors.red.bgGreen(colors.zebra('hello world'));
-      var expected = colors.red.bgGreen(colors.zebra('hello wor')) + '…';
+      let original = colors.red.bgGreen(colors.zebra('hello world'));
+      let expected = colors.red.bgGreen(colors.zebra('hello wor')) + '…';
       expect(truncate(original, 10)).toEqual(expected);
     });
 
     it('handles reset code', function() {
-      var original = '\x1b[31mhello\x1b[0m world';
-      var expected = '\x1b[31mhello\x1b[0m wor…';
+      let original = '\x1b[31mhello\x1b[0m world';
+      let expected = '\x1b[31mhello\x1b[0m wor…';
       expect(truncate(original, 10)).toEqual(expected);
     });
 
     it('handles reset code (EMPTY VERSION)', function() {
-      var original = '\x1b[31mhello\x1b[0m world';
-      var expected = '\x1b[31mhello\x1b[0m wor…';
+      let original = '\x1b[31mhello\x1b[0m world';
+      let expected = '\x1b[31mhello\x1b[0m wor…';
       expect(truncate(original, 10)).toEqual(expected);
     });
 
@@ -180,8 +175,8 @@ describe('utils', function() {
     });
 
     it('handles color code with CJK chars', function() {
-      var original = '漢字\x1b[31m漢字\x1b[0m漢字';
-      var expected = '漢字\x1b[31m漢字\x1b[0m漢…';
+      let original = '漢字\x1b[31m漢字\x1b[0m漢字';
+      let expected = '漢字\x1b[31m漢字\x1b[0m漢…';
       expect(truncate(original, 11)).toEqual(expected);
     });
   });
@@ -227,26 +222,26 @@ describe('utils', function() {
     });
 
     it('chars will be merged deeply', function() {
-      var expected = defaultOptions();
+      let expected = defaultOptions();
       expected.chars.left = 'L';
       expect(mergeOptions({ chars: { left: 'L' } })).toEqual(expected);
     });
 
     it('style will be merged deeply', function() {
-      var expected = defaultOptions();
+      let expected = defaultOptions();
       expected.style['padding-left'] = 2;
       expect(mergeOptions({ style: { 'padding-left': 2 } })).toEqual(expected);
     });
 
     it('head will be overwritten', function() {
-      var expected = defaultOptions();
+      let expected = defaultOptions();
       expected.style.head = [];
       //we can't use lodash's `merge()` in implementation because it would deeply copy array.
       expect(mergeOptions({ style: { head: [] } })).toEqual(expected);
     });
 
     it('border will be overwritten', function() {
-      var expected = defaultOptions();
+      let expected = defaultOptions();
       expected.style.border = [];
       //we can't use lodash's `merge()` in implementation because it would deeply copy array.
       expect(mergeOptions({ style: { border: [] } })).toEqual(expected);
@@ -255,127 +250,127 @@ describe('utils', function() {
 
   describe('wordWrap', function() {
     it('length', function() {
-      var input = 'Hello, how are you today? I am fine, thank you!';
+      let input = 'Hello, how are you today? I am fine, thank you!';
 
-      var expected = 'Hello, how\nare you\ntoday? I\nam fine,\nthank you!';
+      let expected = 'Hello, how\nare you\ntoday? I\nam fine,\nthank you!';
 
       expect(wordWrap(10, input).join('\n')).toEqual(expected);
     });
 
     it.skip('length with colors', function() {
-      var input = colors.red('Hello, how are') + colors.blue(' you today? I') + colors.green(' am fine, thank you!');
+      let input = colors.red('Hello, how are') + colors.blue(' you today? I') + colors.green(' am fine, thank you!');
 
-      var expected =
+      let expected =
         colors.red('Hello, how\nare') + colors.blue(' you\ntoday? I') + colors.green('\nam fine,\nthank you!');
 
       expect(wordWrap(10, input).join('\n')).toEqual(expected);
     });
 
     it('will not create an empty last line', function() {
-      var input = 'Hello Hello ';
+      let input = 'Hello Hello ';
 
-      var expected = 'Hello\nHello';
+      let expected = 'Hello\nHello';
 
       expect(wordWrap(5, input).join('\n')).toEqual(expected);
     });
 
     it('will handle color reset code', function() {
-      var input = '\x1b[31mHello\x1b[0m Hello ';
+      let input = '\x1b[31mHello\x1b[0m Hello ';
 
-      var expected = '\x1b[31mHello\x1b[0m\nHello';
+      let expected = '\x1b[31mHello\x1b[0m\nHello';
 
       expect(wordWrap(5, input).join('\n')).toEqual(expected);
     });
 
     it('will handle color reset code (EMPTY version)', function() {
-      var input = '\x1b[31mHello\x1b[m Hello ';
+      let input = '\x1b[31mHello\x1b[m Hello ';
 
-      var expected = '\x1b[31mHello\x1b[m\nHello';
+      let expected = '\x1b[31mHello\x1b[m\nHello';
 
       expect(wordWrap(5, input).join('\n')).toEqual(expected);
     });
 
     it('words longer than limit will not create extra newlines', function() {
-      var input = 'disestablishment is a multiplicity someotherlongword';
+      let input = 'disestablishment is a multiplicity someotherlongword';
 
-      var expected = 'disestablishment\nis a\nmultiplicity\nsomeotherlongword';
+      let expected = 'disestablishment\nis a\nmultiplicity\nsomeotherlongword';
 
       expect(wordWrap(7, input).join('\n')).toEqual(expected);
     });
 
     it('multiple line input', function() {
-      var input = 'a\nb\nc d e d b duck\nm\nn\nr';
-      var expected = ['a', 'b', 'c d', 'e d', 'b', 'duck', 'm', 'n', 'r'];
+      let input = 'a\nb\nc d e d b duck\nm\nn\nr';
+      let expected = ['a', 'b', 'c d', 'e d', 'b', 'duck', 'm', 'n', 'r'];
 
       expect(wordWrap(4, input)).toEqual(expected);
     });
 
     it('will not start a line with whitespace', function() {
-      var input = 'ab cd  ef gh  ij kl';
-      var expected = ['ab cd', 'ef gh', 'ij kl'];
+      let input = 'ab cd  ef gh  ij kl';
+      let expected = ['ab cd', 'ef gh', 'ij kl'];
       expect(wordWrap(7, input)).toEqual(expected);
     });
 
     it('wraps CJK chars', function() {
-      var input = '漢字 漢\n字 漢字';
-      var expected = ['漢字 漢', '字 漢字'];
+      let input = '漢字 漢\n字 漢字';
+      let expected = ['漢字 漢', '字 漢字'];
       expect(wordWrap(7, input)).toEqual(expected);
     });
 
     it('wraps CJK chars with colors', function() {
-      var input = '\x1b[31m漢字\x1b[0m\n 漢字';
-      var expected = ['\x1b[31m漢字\x1b[0m', ' 漢字'];
+      let input = '\x1b[31m漢字\x1b[0m\n 漢字';
+      let expected = ['\x1b[31m漢字\x1b[0m', ' 漢字'];
       expect(wordWrap(5, input)).toEqual(expected);
     });
   });
 
   describe('colorizeLines', function() {
     it('foreground colors continue on each line', function() {
-      var input = colors.red('Hello\nHi').split('\n');
+      let input = colors.red('Hello\nHi').split('\n');
 
       expect(utils.colorizeLines(input)).toEqual([colors.red('Hello'), colors.red('Hi')]);
     });
 
     it('foreground colors continue on each line', function() {
-      var input = colors.bgRed('Hello\nHi').split('\n');
+      let input = colors.bgRed('Hello\nHi').split('\n');
 
       expect(utils.colorizeLines(input)).toEqual([colors.bgRed('Hello'), colors.bgRed('Hi')]);
     });
 
     it('styles will continue on each line', function() {
-      var input = colors.underline('Hello\nHi').split('\n');
+      let input = colors.underline('Hello\nHi').split('\n');
 
       expect(utils.colorizeLines(input)).toEqual([colors.underline('Hello'), colors.underline('Hi')]);
     });
 
     it('styles that end before the break will not be applied to the next line', function() {
-      var input = (colors.underline('Hello') + '\nHi').split('\n');
+      let input = (colors.underline('Hello') + '\nHi').split('\n');
 
       expect(utils.colorizeLines(input)).toEqual([colors.underline('Hello'), 'Hi']);
     });
 
     it('the reset code can be used to drop styles', function() {
-      var input = '\x1b[31mHello\x1b[0m\nHi'.split('\n');
+      let input = '\x1b[31mHello\x1b[0m\nHi'.split('\n');
       expect(utils.colorizeLines(input)).toEqual(['\x1b[31mHello\x1b[0m', 'Hi']);
     });
 
     it('handles aixterm 16-color foreground', function() {
-      var input = '\x1b[90mHello\nHi\x1b[0m'.split('\n');
+      let input = '\x1b[90mHello\nHi\x1b[0m'.split('\n');
       expect(utils.colorizeLines(input)).toEqual(['\x1b[90mHello\x1b[39m', '\x1b[90mHi\x1b[0m']);
     });
 
     it('handles aixterm 16-color background', function() {
-      var input = '\x1b[100mHello\nHi\x1b[m\nHowdy'.split('\n');
+      let input = '\x1b[100mHello\nHi\x1b[m\nHowdy'.split('\n');
       expect(utils.colorizeLines(input)).toEqual(['\x1b[100mHello\x1b[49m', '\x1b[100mHi\x1b[m', 'Howdy']);
     });
 
     it('handles aixterm 256-color foreground', function() {
-      var input = '\x1b[48;5;8mHello\nHi\x1b[0m\nHowdy'.split('\n');
+      let input = '\x1b[48;5;8mHello\nHi\x1b[0m\nHowdy'.split('\n');
       expect(utils.colorizeLines(input)).toEqual(['\x1b[48;5;8mHello\x1b[49m', '\x1b[48;5;8mHi\x1b[0m', 'Howdy']);
     });
 
     it('handles CJK chars', function() {
-      var input = colors.red('漢字\nテスト').split('\n');
+      let input = colors.red('漢字\nテスト').split('\n');
 
       expect(utils.colorizeLines(input)).toEqual([colors.red('漢字'), colors.red('テスト')]);
     });

--- a/test/verify-legacy-compatibility-test.js
+++ b/test/verify-legacy-compatibility-test.js
@@ -8,18 +8,18 @@
   });
 
   function commonTests(Table) {
-    var colors = require('colors/safe');
+    const colors = require('colors/safe');
 
     it('empty table has a width of 0', function() {
-      var table = new Table();
+      let table = new Table();
       expect(table.width).toEqual(0);
       expect(table.toString()).toEqual('');
     });
 
     it('header text will be colored according to style', function() {
-      var table = new Table({ head: ['hello', 'goodbye'], style: { border: [], head: ['red', 'bgWhite'] } });
+      let table = new Table({ head: ['hello', 'goodbye'], style: { border: [], head: ['red', 'bgWhite'] } });
 
-      var expected = [
+      let expected = [
         '┌───────┬─────────┐',
         '│' + colors.bgWhite.red(' hello ') + '│' + colors.bgWhite.red(' goodbye ') + '│',
         '└───────┴─────────┘',
@@ -29,21 +29,21 @@
     });
 
     it('tables with one row of data will not be treated as headers', function() {
-      var table = new Table({ style: { border: [], head: ['red'] } });
+      let table = new Table({ style: { border: [], head: ['red'] } });
 
       table.push(['hello', 'goodbye']);
 
-      var expected = ['┌───────┬─────────┐', '│ hello │ goodbye │', '└───────┴─────────┘'];
+      let expected = ['┌───────┬─────────┐', '│ hello │ goodbye │', '└───────┴─────────┘'];
 
       expect(table.toString()).toEqual(expected.join('\n'));
     });
 
     it('table with headers and data headers', function() {
-      var table = new Table({ head: ['hello', 'goodbye'], style: { border: [], head: ['red'] } });
+      let table = new Table({ head: ['hello', 'goodbye'], style: { border: [], head: ['red'] } });
 
       table.push(['hola', 'adios']);
 
-      var expected = [
+      let expected = [
         '┌───────┬─────────┐',
         '│' + colors.red(' hello ') + '│' + colors.red(' goodbye ') + '│',
         '├───────┼─────────┤',
@@ -55,21 +55,21 @@
     });
 
     it('compact shorthand', function() {
-      var table = new Table({ style: { compact: true, border: [], head: ['red'] } });
+      let table = new Table({ style: { compact: true, border: [], head: ['red'] } });
 
       table.push(['hello', 'goodbye'], ['hola', 'adios']);
 
-      var expected = ['┌───────┬─────────┐', '│ hello │ goodbye │', '│ hola  │ adios   │', '└───────┴─────────┘'];
+      let expected = ['┌───────┬─────────┐', '│ hello │ goodbye │', '│ hola  │ adios   │', '└───────┴─────────┘'];
 
       expect(table.toString()).toEqual(expected.join('\n'));
     });
 
     it('compact shorthand - headers are still rendered with separator', function() {
-      var table = new Table({ head: ['hello', 'goodbye'], style: { compact: true, border: [], head: [] } });
+      let table = new Table({ head: ['hello', 'goodbye'], style: { compact: true, border: [], head: [] } });
 
       table.push(['hola', 'adios'], ['hi', 'bye']);
 
-      var expected = [
+      let expected = [
         '┌───────┬─────────┐',
         '│ hello │ goodbye │',
         '├───────┼─────────┤',
@@ -82,7 +82,7 @@
     });
 
     it('compact longhand - headers are not rendered with separator', function() {
-      var table = new Table({
+      let table = new Table({
         chars: {
           mid: '',
           'left-mid': '',
@@ -95,7 +95,7 @@
 
       table.push(['hola', 'adios'], ['hi', 'bye']);
 
-      var expected = [
+      let expected = [
         '┌───────┬─────────┐',
         '│ hello │ goodbye │',
         '│ hola  │ adios   │',
@@ -107,7 +107,7 @@
     });
 
     it('compact longhand', function() {
-      var table = new Table({
+      let table = new Table({
         chars: {
           mid: '',
           'left-mid': '',
@@ -119,19 +119,19 @@
 
       table.push(['hello', 'goodbye'], ['hola', 'adios']);
 
-      var expected = ['┌───────┬─────────┐', '│ hello │ goodbye │', '│ hola  │ adios   │', '└───────┴─────────┘'];
+      let expected = ['┌───────┬─────────┐', '│ hello │ goodbye │', '│ hola  │ adios   │', '└───────┴─────────┘'];
 
       expect(table.toString()).toEqual(expected.join('\n'));
     });
 
     it('objects with multiple properties in a cross-table', function() {
-      var table = new Table({ style: { border: [], head: [] } });
+      let table = new Table({ style: { border: [], head: [] } });
 
       table.push(
         { a: ['b'], c: ['d'] } // value of property 'c' will be discarded
       );
 
-      var expected = ['┌───┬───┐', '│ a │ b │', '└───┴───┘'];
+      let expected = ['┌───┬───┐', '│ a │ b │', '└───┴───┘'];
       expect(table.toString()).toEqual(expected.join('\n'));
     });
   }


### PR DESCRIPTION
This PR updates the code to use `let/const` instead of `var` and ES6 class syntax to make the code more readable.