### PR TITLE
ci: remove NodeJS 6 and add NodeJS latest (13)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"
+  - "node"
 
 cache: yarn
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "homepage": "https://github.com/cli-table/cli-table3",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "changelog": {
     "repo": "cli-table/cli-table3",


### PR DESCRIPTION
The current eslint version needs NodeJS >= 8.

See https://travis-ci.com/cli-table/cli-table3/jobs/252453197

> error eslint@6.6.0: The engine "node" is incompatible with this module. Expected version "^8.10.0 || ^10.13.0 || >=11.10.1". Got "6.17.1"