### PR TITLE
Drop support for Node 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "6"
-  - "8"
   - "10"
   - "12"
+  - "13"
 
 cache: yarn
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "homepage": "https://github.com/cli-table/cli-table3",
   "engines": {
-    "node": ">=6"
+    "node": "10.* || >= 12.*"
   },
   "changelog": {
     "repo": "cli-table/cli-table3",


### PR DESCRIPTION
These versions are no longer maintained by the Node.js team, so we should drop support to unblock some of the open dependency updates.

Closes #133