### PR TITLE
Remove obsolete `Object.assign()` polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "test"
   },
   "dependencies": {
-    "object-assign": "^4.1.0",
     "string-width": "^4.2.0"
   },
   "devDependencies": {

--- a/src/layout-manager.js
+++ b/src/layout-manager.js
@@ -1,4 +1,3 @@
-const objectAssign = require('object-assign');
 const Cell = require('./cell');
 const { ColSpanCell, RowSpanCell } = Cell;
 
@@ -226,7 +225,7 @@ function makeComputeWidths(colSpan, desiredWidth, x, forcedMin) {
       }
     }
 
-    objectAssign(vals, result);
+    Object.assign(vals, result);
     for (let j = 0; j < vals.length; j++) {
       vals[j] = Math.max(forcedMin, vals[j] || 0);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-const objectAssign = require('object-assign');
 const stringWidth = require('string-width');
 
 function codeRegex(capture) {
@@ -235,9 +234,9 @@ function defaultOptions() {
 function mergeOptions(options, defaults) {
   options = options || {};
   defaults = defaults || defaultOptions();
-  let ret = objectAssign({}, defaults, options);
-  ret.chars = objectAssign({}, defaults.chars, options.chars);
-  ret.style = objectAssign({}, defaults.style, options.style);
+  let ret = Object.assign({}, defaults, options);
+  ret.chars = Object.assign({}, defaults.chars, options.chars);
+  ret.style = Object.assign({}, defaults.style, options.style);
   return ret;
 }
 
@@ -286,7 +285,7 @@ function colorizeLines(input) {
   for (let i = 0; i < input.length; i++) {
     let line = rewindState(state, input[i]);
     state = readState(line);
-    let temp = objectAssign({}, state);
+    let temp = Object.assign({}, state);
     output.push(unwindState(temp, line));
   }
   return output;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3242,7 +3242,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=


### PR DESCRIPTION
cli-table3 can use Object.assign() directly since it targets Node.js 10+.