### PR TITLE
`colors.js` has issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "2.3.2"
   },
   "optionalDependencies": {
-    "@dabh/colors": "^1.1.2"
+    "colors": "1.4.0"
   },
   "scripts": {
     "changelog": "lerna-changelog",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "2.3.2"
   },
   "optionalDependencies": {
-    "colors": "^1.1.2"
+    "@dabh/colors": "^1.1.2"
   },
   "scripts": {
     "changelog": "lerna-changelog",


### PR DESCRIPTION
Mainly, this https://github.com/Marak/colors.js/issues/285 Latest version has been compromised. A  former maintainer, @dabh, has released this alternative 1.4.0 version.
Alternatively, it could simply be eliminated, since it's optional.