### PR TITLE
#196 - Fix failing test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "changelog": "lerna-changelog",
     "docs": "node ./scripts/update-docs.js",
     "prettier": "prettier --write '{examples,lib,scripts,src,test}/**/*.js'",
-    "test": "jest --color",
-    "test:watch": "jest --color --watchAll --notify"
+    "test": "jest --color --runInBand",
+    "test:watch": "jest --color --runInBand --watchAll --notify"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This resolves #196.

The tests fail (at least for me and some others) because of the reasons described in #196. This update merely adds the `--runInBand` flag to the test "scripts".
