### PR TITLE
#269 - Refactored table layouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
       {
         "displayName": "test",
         "testMatch": [
-          "<rootDir>/test/*.js"
+          "<rootDir>/test/**/*.js"
         ]
       },
       {

--- a/test/issues/269-test.js
+++ b/test/issues/269-test.js
@@ -1,0 +1,16 @@
+const Table = require('../..');
+
+test('it renders rowSpan correctly', () => {
+  let table = new Table({ style: { border: [], head: [] } });
+  table.push([{ rowSpan: 3, content: 'A1' }, 'B1', 'C1'], [{ rowSpan: 2, content: 'B2' }, 'C2'], ['C3']);
+  let expected = [
+    '┌────┬────┬────┐',
+    '│ A1 │ B1 │ C1 │',
+    '│    ├────┼────┤',
+    '│    │ B2 │ C2 │',
+    '│    │    ├────┤',
+    '│    │    │ C3 │',
+    '└────┴────┴────┘',
+  ];
+  expect(table.toString()).toEqual(expected.join('\n'));
+});

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -62,6 +62,73 @@ describe('@api Table ', function () {
 
     expect(table.toString()).toEqual(expected.join('\n'));
   });
+
+  it('supports complex layouts', () => {
+    let table = new Table({ style: { border: [], head: [] } });
+    table.push(
+      [{ content: 'TOP', colSpan: 9, hAlign: 'center' }],
+      [
+        { content: 'TL', rowSpan: 4, vAlign: 'center' },
+        { content: 'A1', rowSpan: 3 },
+        'B1',
+        'C1',
+        { content: 'D1', rowSpan: 3, vAlign: 'center' },
+        'E1',
+        'F1',
+        { content: 'G1', rowSpan: 3 },
+        { content: 'TR', rowSpan: 4, vAlign: 'center' },
+      ],
+      [{ rowSpan: 2, content: 'B2' }, 'C2', { rowSpan: 2, colSpan: 2, content: 'E2' }],
+      ['C3'],
+      [{ content: 'A2', colSpan: 7, hAlign: 'center' }],
+      [{ content: 'CLEAR', colSpan: 9, hAlign: 'center' }],
+      [
+        { content: 'BL', rowSpan: 4, vAlign: 'center' },
+        { content: 'A3', colSpan: 7, hAlign: 'center' },
+        { content: 'BR', rowSpan: 4, vAlign: 'center' },
+      ],
+      [
+        { content: 'A4', colSpan: 3, hAlign: 'center' },
+        { content: 'D2', rowSpan: 2, vAlign: 'center' },
+        { content: 'E3', colSpan: 2, hAlign: 'center' },
+        { content: 'G2', rowSpan: 3, vAlign: 'center' },
+      ],
+      [
+        { content: 'A5', rowSpan: 2, vAlign: 'center' },
+        { content: 'B3', colSpan: 2, hAlign: 'center' },
+        { content: 'E4', rowSpan: 2, vAlign: 'center' },
+        { content: 'F3', rowSpan: 2, vAlign: 'center' },
+      ],
+      ['B4', { content: 'C4', colSpan: 2, hAlign: 'center' }],
+      [{ content: 'BOTTOM', colSpan: 9, hAlign: 'center' }]
+    );
+    let expected = [
+      '┌────────────────────────────────────────────┐',
+      '│                    TOP                     │',
+      '├────┬────┬────┬────┬────┬────┬────┬────┬────┤',
+      '│    │ A1 │ B1 │ C1 │    │ E1 │ F1 │ G1 │    │',
+      '│    │    ├────┼────┤    ├────┴────┤    │    │',
+      '│    │    │ B2 │ C2 │ D1 │ E2      │    │    │',
+      '│ TL │    │    ├────┤    │         │    │ TR │',
+      '│    │    │    │ C3 │    │         │    │    │',
+      '│    ├────┴────┴────┴────┴─────────┴────┤    │',
+      '│    │                A2                │    │',
+      '├────┴──────────────────────────────────┴────┤',
+      '│                   CLEAR                    │',
+      '├────┬──────────────────────────────────┬────┤',
+      '│    │                A3                │    │',
+      '│    ├──────────────┬────┬─────────┬────┤    │',
+      '│    │      A4      │    │   E3    │    │    │',
+      '│ BL ├────┬─────────┤ D2 ├────┬────┤    │ BR │',
+      '│    │    │   B3    │    │    │    │ G2 │    │',
+      '│    │ A5 ├────┬────┴────┤ E4 │ F3 │    │    │',
+      '│    │    │ B4 │   C4    │    │    │    │    │',
+      '├────┴────┴────┴─────────┴────┴────┴────┴────┤',
+      '│                   BOTTOM                   │',
+      '└────────────────────────────────────────────┘',
+    ];
+    expect(table.toString()).toEqual(expected.join('\n'));
+  });
 });
 
 /*


### PR DESCRIPTION
Been attempting to ensure support for all varieties of table-layouts as well as reducing the time-complexity. This PR will solve #269 as well as open the door to supporting larger datasets and faster rendering.

Previously, when layout is being calculated, for each cell in the table it would traverse all cells that had come before it. It was not able to detect rowSpans left-wards beyond the immediate left. Not sure how to express this mathematically, but the time-complexity is/was exponential.

With this refactored table layout, the time-complexity is mostly reduced to match the complexity of the table. 

**The first commit includes failing tests.** One specifically for #269 and one generally that demonstrates an advanced implementation of rowSpan and colSpan.