### PR TITLE
#196 - Fix to failing unit tests

### DIFF
--- a/test/verify-legacy-compatibility-test.js
+++ b/test/verify-legacy-compatibility-test.js
@@ -1,3 +1,4 @@
+jest.mock('colors/safe', () => jest.requireActual('@colors/colors/safe'));
 (function () {
   describe('verify original cli-table behavior', function () {
     commonTests(require('cli-table'));


### PR DESCRIPTION
This mocks the colors module within the "legacy tests" to produce consistent output from colors—as the tests expect.

This one-liner appropriately resolves #196.