### PR TITLE
Fix: Correctly set cell padding for zero values

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -326,15 +326,19 @@ class RowSpanCell {
   mergeTableOptions() {}
 }
 
+function firstDefined(...args) {
+  return args.filter((v) => v !== undefined && v !== null).shift();
+}
+
 // HELPER FUNCTIONS
 function setOption(objA, objB, nameB, targetObj) {
   let nameA = nameB.split('-');
   if (nameA.length > 1) {
     nameA[1] = nameA[1].charAt(0).toUpperCase() + nameA[1].substr(1);
     nameA = nameA.join('');
-    targetObj[nameA] = objA[nameA] || objA[nameB] || objB[nameA] || objB[nameB];
+    targetObj[nameA] = firstDefined(objA[nameA], objA[nameB], objB[nameA], objB[nameB]);
   } else {
-    targetObj[nameB] = objA[nameB] || objB[nameB];
+    targetObj[nameB] = firstDefined(objA[nameB], objB[nameB]);
   }
 }
 

--- a/test/issues/124-test.js
+++ b/test/issues/124-test.js
@@ -1,0 +1,49 @@
+const Table = require('../..');
+
+test('cell padding of zero overrides table options', () => {
+  let table = new Table({
+    style: {
+      'padding-left': 1,
+      //      'padding-right': 1,
+      border: [],
+      header: [],
+    },
+  });
+
+  table.push([
+    {
+      content: 'a',
+      style: {
+        'padding-left': 5,
+      },
+    },
+    {
+      content: 'b',
+      style: {
+        'padding-left': 2,
+        'padding-right': 0,
+      },
+    },
+    {
+      content: 'c',
+      style: {
+        'padding-left': 0,
+      },
+    },
+    {
+      content: 'd',
+      style: {
+        'padding-left': 0,
+        'padding-right': 2,
+      },
+    },
+  ]);
+
+  const expected = [
+    // prettier-disable
+    '┌───────┬───┬──┬───┐',
+    '│     a │  b│c │d  │',
+    '└───────┴───┴──┴───┘',
+  ].join('\n');
+  expect(table.toString()).toEqual(expected);
+});


### PR DESCRIPTION
This addresses the issue reported in #124.

When setting cell options, it was taking the first truthy value and therefore any zero (0) values were being ignored.