### PR TITLE
Hyperlink support for cells

### DIFF
--- a/basic-usage.md
+++ b/basic-usage.md
@@ -166,3 +166,31 @@
       table.push(['Wrap', 'Text']);
 ```
 
+
+##### Supports hyperlinking cell content using the href option
+    ┌───────────┬─────┬─────┐
+    │ Text Link │ Hel │ htt │
+    │           │ lo  │ p:/ │
+    │           │ Lin │ /ex │
+    │           │ k   │ amp │
+    │           │     │ le. │
+    │           │     │ com │
+    ├───────────┴─────┴─────┤
+    │ http://example.com    │
+    └───────────────────────┘
+    
+    Note: Links are not displayed in documentation examples.
+```javascript
+      const table = new Table({
+        colWidths: [11, 5, 5],
+        style: { border: [], head: [] },
+        wordWrap: true,
+        wrapOnWordBoundary: false,
+      });
+      const href = 'http://example.com';
+      table.push(
+        [{ content: 'Text Link', href }, { content: 'Hello Link', href }, { href }],
+        [{ href, colSpan: 3 }]
+      );
+```
+

--- a/examples/basic-usage-examples.js
+++ b/examples/basic-usage-examples.js
@@ -1,5 +1,6 @@
 const Table = require('../src/table');
 const colors = require('@colors/colors/safe');
+const { hyperlink } = require('../src/utils');
 
 // prettier-ignore
 // Disable prettier so that examples are formatted more clearly
@@ -235,6 +236,40 @@ module.exports = function (runTest) {
 
     return [makeTable, expected];
   });
+
+  it('Supports hyperlinking cell content using the href option', () => {
+    function link(text) {
+      return hyperlink('http://example.com', text);
+    }
+    function makeTable() {
+      const table = new Table({
+        colWidths: [11, 5, 5],
+        style: { border: [], head: [] },
+        wordWrap: true,
+        wrapOnWordBoundary: false,
+      });
+      const href = 'http://example.com';
+      table.push(
+        [{ content: 'Text Link', href }, { content: 'Hello Link', href }, { href }],
+        [{ href, colSpan: 3 }]
+      );
+      return table;
+    }
+
+    let expected = [
+      '┌───────────┬─────┬─────┐',
+      `│ ${link('Text Link')} │ ${link('Hel')} │ ${link('htt')} │`,
+      `│           │ ${link('lo ')} │ ${link('p:/')} │`,
+      `│           │ ${link('Lin')} │ ${link('/ex')} │`,
+      `│           │ ${link('k')}   │ ${link('amp')} │`,
+      `│           │     │ ${link('le.')} │`,
+      `│           │     │ ${link('com')} │`,
+      '├───────────┴─────┴─────┤',
+      `│ ${link('http://example.com')}    │`,
+      '└───────────────────────┘',
+    ];
+    return [makeTable, expected];
+  });
 };
 
 /* Expectation - ready to be copy/pasted and filled in. DO NOT DELETE THIS
@@ -250,3 +285,4 @@ module.exports = function (runTest) {
  , '└──┴───┴──┴──┘'
  ];
  */
+// Jest Snapshot v1, https://goo.gl/fbAQLP

--- a/lib/print-example.js
+++ b/lib/print-example.js
@@ -17,6 +17,18 @@ function logExample(fn) {
   );
 }
 
+function replaceLinks(str) {
+  const matches = str.match(/\x1B\]8;;[^\x07]+\x07[^\]]+\x1B\]8;;\x07/g);
+  if (matches) {
+    matches.forEach((match) => {
+      const [, text] = match.match(/\x07([^\]|\x1B]+)\x1B/);
+      str = str.replace(match, text);
+    });
+    str += '\n\nNote: Links are not displayed in documentation examples.';
+  }
+  return str;
+}
+
 function mdExample(fn, file, cb) {
   let buffer = [];
 
@@ -27,7 +39,7 @@ function mdExample(fn, file, cb) {
     },
     function logTable(table) {
       //md files won't render color strings properly.
-      table = stripColors(table);
+      table = replaceLinks(stripColors(table));
 
       // indent table so is displayed preformatted text
       table = '    ' + table.split('\n').join('\n    ');

--- a/src/utils.js
+++ b/src/utils.js
@@ -314,10 +314,14 @@ function colorizeLines(input) {
 }
 
 /**
- * Placeholder for failing tests.
+ * Credit: Matheus Sampaio https://github.com/matheussampaio
  */
 function hyperlink(url, text) {
-  return url || text; // inverse of what it should be
+  const OSC = '\u001B]';
+  const BEL = '\u0007';
+  const SEP = ';';
+
+  return [OSC, '8', SEP, SEP, url || text, BEL, text, OSC, '8', SEP, SEP, BEL].join('');
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -313,6 +313,13 @@ function colorizeLines(input) {
   return output;
 }
 
+/**
+ * Placeholder for failing tests.
+ */
+function hyperlink(url, text) {
+  return url || text; // inverse of what it should be
+}
+
 module.exports = {
   strlen: strlen,
   repeat: repeat,
@@ -321,4 +328,5 @@ module.exports = {
   mergeOptions: mergeOptions,
   wordWrap: multiLineWordWrap,
   colorizeLines: colorizeLines,
+  hyperlink,
 };

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -387,4 +387,16 @@ describe('utils', function () {
       expect(utils.colorizeLines(input)).toEqual([colors.red('漢字'), colors.red('テスト')]);
     });
   });
+
+  describe('hyperlink', function () {
+    const url = 'http://example.com';
+    const text = 'hello link';
+    const expected = (u, t) => `\x1B]8;;${u}\x07${t}\x1B]8;;\x07`;
+    it('wraps text with link', () => {
+      expect(utils.hyperlink(url, text)).toEqual(expected(url, text));
+    });
+    it('defaults text to link', () => {
+      expect(utils.hyperlink(url, url)).toEqual(expected(url, url));
+    });
+  });
 });


### PR DESCRIPTION
This PR adds support for hyperlinks using a very simple interface. This feature was requested in #73 

```
table.push([
  // Specify the URL as the display text
  { href: 'http://example.com' }, 
  // Specify display text
  { href: 'http://example.com', content: 'Example text' },
]);
```

**Link text is wrapped, truncated, etc. as usual but when the text of a cell spans multiple lines, each link is wrapped with the link.**

PR includes:

- Added `utils.hyplerink()` with unit tests (with credits to @matheussampaio)
- Added hyperlink support to `Cell` with functional tests that generate documentation
- Updated documentation `basic-usage.md`

The difference in functionality is not meaningfully demonstrable in markdown. Examine the (failing/passing) tests in _Checks_ to inspect the differences.