### PR TITLE
feat: ability to set/override wordWrap and wrapOnWordBoundary options per cell

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -73,7 +73,9 @@ class Cell {
   }
 
   computeLines(tableOptions) {
-    if (this.fixedWidth && (tableOptions.wordWrap || tableOptions.textWrap)) {
+    const tableWordWrap = tableOptions.wordWrap || tableOptions.textWrap;
+    const { wordWrap = tableWordWrap } = this.options;
+    if (this.fixedWidth && wordWrap) {
       this.fixedWidth -= this.paddingLeft + this.paddingRight;
       if (this.colSpan) {
         let i = 1;
@@ -82,7 +84,8 @@ class Cell {
           i++;
         }
       }
-      const { wrapOnWordBoundary = true } = tableOptions;
+      const { wrapOnWordBoundary: tableWrapOnWordBoundary = true } = tableOptions;
+      const { wrapOnWordBoundary = tableWrapOnWordBoundary } = this.options;
       return this.wrapLines(utils.wordWrap(this.fixedWidth, this.content, wrapOnWordBoundary));
     }
     return this.wrapLines(this.content.split('\n'));


### PR DESCRIPTION
## Description

This adds the ability to set `wordWrap` and `wrapOnWordBoundary` options per cell, instead of it being set globally via the table options.

Use case is for when you want one column to have `wrapOnWordBoundary=false`, and another column with `wrapOnWordBoundary=true` (see screenshot and sample code)

## Sample Code

```javascript
const Table = require("cli-table3");

let table = new Table({
  style: { head: [], border: [] },
  colWidths: [15, 50],
  wordWrap: true,
  wrapOnWordBoundary: true
});

table.push(
  ['URLs', 'Description'],
  [{ content: 'https://en.wikipedia.org/wiki/Voyager_program', wrapOnWordBoundary: false }, { content: 'The Voyager program is an American scientific program that employs two robotic interstellar probes, Voyager 1 and Voyager 2. They were launched in 1977 to take advantage of a favorable alignment of Jupiter and Saturn, to fly near them while collecting data for transmission back to Earth. After launch the decision was taken to send Voyager 2 near Uranus and Neptune to collect data for transmission back to Earth.'}],
  [{ content: 'https://en.wikipedia.org/wiki/SpaceX', wrapOnWordBoundary: false }, { content: 'Space Exploration Technologies Corp. (doing business as SpaceX) is an American spacecraft manufacturer, space launch provider, and a satellite communications corporation headquartered in Hawthorne, California. SpaceX was founded in 2002 by Elon Musk, with the goal of reducing space transportation costs to enable the colonization of Mars. SpaceX manufactures the Falcon 9 and Falcon Heavy launch vehicles, several rocket engines, Cargo Dragon, crew spacecraft, and Starlink communications satellites.' }]
);

console.log(table.toString())
```

## Screenshot

<img width="543" alt="image" src="https://user-images.githubusercontent.com/36107/175774380-4a14e1fc-c113-43d4-b3be-b4a1a472755d.png">

