### PR TITLE
Add assertion to test scripted examples

### DIFF
--- a/lib/print-example.js
+++ b/lib/print-example.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 /* eslint-disable no-console */
 
+const assert = require('assert');
 const colors = require('@colors/colors/safe');
 const fs = require('fs');
 
@@ -102,6 +103,24 @@ function runPrintingExample(fn, logName, logTable, logCode, logSeparator, logScr
    */
   function printExample(name, makeTable, expected, screenshot) {
     let code = makeTable.toString().split('\n').slice(1, -2).join('\n');
+
+    /**
+     * The scripts that generate the cli-table3 docs include "testing" routines
+     * which never actually get tested. It's unclear whether this was lost or
+     * dropped somewhere along the way.
+     *
+     * Here I've added a simple routine that tests the tables generated with the
+     * defined expectations.
+     *
+     * This proved pertinent when adding a bulk of new documentation examples so
+     * as to prevent innaccurate documentation and to make some use of the
+     * "framework" that was already there.
+     *
+     * It would be ideal if these "tests" were induced with the jest tests, but
+     * as is they are only induced within the "print-examples" and "update-docs"
+     * scripts. —@speedytwenty
+     */
+    assert.equal(makeTable().toString(), expected.join('\n'));
 
     logName(name);
     if (screenshot && logScreenShot) {


### PR DESCRIPTION
The scripts that generate the cli-table3 docs include "testing" routines which never actually get tested. It's unclear whether this was lost or dropped somewhere along the way.

Here I've added a simple routine that tests the tables generated with the defined expectations.

It would be ideal if these "tests" were induced with the jest tests, but as is they are only induced within the "print-examples" and "update-docs" scripts.