### PR TITLE
add word wrap options to CellOptions ts interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,8 @@ declare namespace CliTable3 {
         rowSpan?: number;
         hAlign?: HorizontalAlignment;
         vAlign?: VerticalAlignment;
+        wordWrap?: boolean;
+        wrapOnWordBoundary?: boolean;
         href?: string;
         style?: {
             "padding-left"?: number;


### PR DESCRIPTION
The code supports setting `wordWrap` and `wrapOnWordBoundary` on a per-cell basis, but the Typescript definitions do not.