### PR TITLE
support bigint cell content type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   env: {
     node: true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ declare namespace CliTable3 {
         style?: Partial<TableInstanceOptions["style"]>;
     }
 
-    type CellValue = boolean | number | string | null | undefined;
+    type CellValue = boolean | number | bigint | string | null | undefined;
 
     interface CellOptions {
         content: CellValue;

--- a/src/cell.js
+++ b/src/cell.js
@@ -22,13 +22,13 @@ class Cell {
   }
 
   setOptions(options) {
-    if (['boolean', 'number', 'string'].indexOf(typeof options) !== -1) {
+    if (['boolean', 'number', 'bigint', 'string'].indexOf(typeof options) !== -1) {
       options = { content: '' + options };
     }
     options = options || {};
     this.options = options;
     let content = options.content;
-    if (['boolean', 'number', 'string'].indexOf(typeof content) !== -1) {
+    if (['boolean', 'number', 'bigint', 'string'].indexOf(typeof content) !== -1) {
       this.content = String(content);
     } else if (!content) {
       this.content = this.options.href || '';

--- a/test/cell-test.js
+++ b/test/cell-test.js
@@ -88,6 +88,16 @@ describe('Cell', function () {
       expect(cell.content).toEqual('0');
     });
 
+    it('new Cell(1n) will have "1" as content', function () {
+      let cell = new Cell(1n);
+      expect(cell.content).toEqual('1');
+    });
+
+    it('new Cell({content: 1n}) will have "1" as content', function () {
+      let cell = new Cell({ content: 1n });
+      expect(cell.content).toEqual('1');
+    });
+
     it('new Cell(false) will have "false" as content', function () {
       let cell = new Cell(false);
       expect(cell.content).toEqual('false');


### PR DESCRIPTION
The existing type casting (`String(value)`) also works for `BigInt`s, so I've added support in the Typescript definitions and the JS type checks.